### PR TITLE
 tests: add reusable harness and expand integration coverage for current Fluent Bit features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # Fluent Bit Python Integration Test Suite
 
+## Status In Fluent Bit
+
+This suite is included under `tests/fluent-bit-test-suite` as an in-tree developer test harness.
+
+It is intended for local development, plugin validation, and focused regression work.
+
+It is not wired into the default Fluent Bit CMake test targets, `ctest`, or the default GitHub Actions workflows in this repository.
+
+## Quick Start
+
+From the repository root:
+
+```bash
+cd tests/fluent-bit-test-suite
+./setup-venv.sh
+./run_tests.py --list
+./run_tests.py
+```
+
+By default the suite looks for `build/bin/fluent-bit`. You can override that with `FLUENT_BIT_BINARY=/path/to/fluent-bit`.
+
 ## What This Is
 
 This is a binary-level integration test harness for Fluent Bit.
@@ -415,6 +436,24 @@ Run the full suite:
 
 ```bash
 ./tests/fluent-bit-test-suite/.venv/bin/pytest -q tests/fluent-bit-test-suite
+```
+
+List tests with the local wrapper:
+
+```bash
+./tests/fluent-bit-test-suite/run_tests.py --list
+```
+
+Run tests with a simple checkbox progress view:
+
+```bash
+./tests/fluent-bit-test-suite/run_tests.py
+```
+
+Run a subset:
+
+```bash
+./tests/fluent-bit-test-suite/run_tests.py scenarios/in_opentelemetry -k oauth2
 ```
 
 Run against a different binary:

--- a/config.yaml
+++ b/config.yaml
@@ -1,2 +1,2 @@
-fluent_bit_binary: /Users/edsiper/coding/fluent-bit/build/bin/fluent-bit
+fluent_bit_binary: build/bin/fluent-bit
 config_path: fluent-bit.yaml

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+
+SUITE_ROOT = Path(__file__).resolve().parent
+VENV_PYTHON = SUITE_ROOT / ".venv" / "bin" / "python3"
+REEXEC_ENV = "FLB_SUITE_WRAPPER_REEXEC"
+
+
+def _maybe_reexec_in_venv() -> None:
+    if os.environ.get(REEXEC_ENV) == "1":
+        return
+
+    if not VENV_PYTHON.is_file():
+        return
+
+    current = Path(sys.executable).resolve()
+    target = VENV_PYTHON.resolve()
+
+    if current == target:
+        return
+
+    env = os.environ.copy()
+    env[REEXEC_ENV] = "1"
+    os.execve(str(target), [str(target), str(Path(__file__).resolve()), *sys.argv[1:]], env)
+
+
+_maybe_reexec_in_venv()
+
+try:
+    import pytest  # noqa: E402
+except ModuleNotFoundError:
+    if VENV_PYTHON.is_file() and os.environ.get(REEXEC_ENV) != "1":
+        env = os.environ.copy()
+        env[REEXEC_ENV] = "1"
+        os.execve(str(VENV_PYTHON), [str(VENV_PYTHON), str(Path(__file__).resolve()), *sys.argv[1:]], env)
+    raise
+
+
+STATUS_PENDING = "pending"
+STATUS_RUNNING = "running"
+STATUS_PASSED = "passed"
+STATUS_FAILED = "failed"
+STATUS_SKIPPED = "skipped"
+
+STATUS_ICON = {
+    STATUS_PENDING: "[ ]",
+    STATUS_RUNNING: "[>]",
+    STATUS_PASSED: "[x]",
+    STATUS_FAILED: "[!]",
+    STATUS_SKIPPED: "[-]",
+}
+
+
+def scenario_name_from_nodeid(nodeid: str) -> str:
+    path = nodeid.split("::", 1)[0]
+    parts = path.split("/")
+    if "scenarios" in parts:
+        index = parts.index("scenarios")
+        if index + 1 < len(parts):
+            return parts[index + 1]
+    return Path(path).stem
+
+
+def short_name_from_nodeid(nodeid: str) -> str:
+    path, _, test_name = nodeid.partition("::")
+    return f"{Path(path).name}::{test_name}" if test_name else Path(path).name
+
+
+class CollectPlugin:
+    def __init__(self) -> None:
+        self.nodeids: list[str] = []
+
+    def pytest_collection_modifyitems(self, session, config, items):
+        self.nodeids = [item.nodeid for item in items]
+
+
+class CheckboxProgressPlugin:
+    def __init__(self) -> None:
+        self.nodeids: list[str] = []
+        self.statuses: OrderedDict[str, str] = OrderedDict()
+        self.terminal_reporter = None
+        self.use_tty = sys.stdout.isatty()
+        self._listed_non_tty = False
+
+    def pytest_configure(self, config):
+        self.terminal_reporter = config.pluginmanager.getplugin("terminalreporter")
+
+    def pytest_collection_modifyitems(self, session, config, items):
+        self.nodeids = [item.nodeid for item in items]
+        self.statuses = OrderedDict((nodeid, STATUS_PENDING) for nodeid in self.nodeids)
+        self._render()
+
+    def pytest_runtest_logstart(self, nodeid, location):
+        if nodeid in self.statuses and self.statuses[nodeid] == STATUS_PENDING:
+            self.statuses[nodeid] = STATUS_RUNNING
+            self._render(changed_nodeid=nodeid)
+
+    def pytest_runtest_logreport(self, report):
+        nodeid = report.nodeid
+        if nodeid not in self.statuses:
+            return
+
+        if report.when == "setup" and report.skipped:
+            self.statuses[nodeid] = STATUS_SKIPPED
+            self._render(changed_nodeid=nodeid)
+            return
+
+        if report.when == "call":
+            if report.passed:
+                self.statuses[nodeid] = STATUS_PASSED
+            elif report.failed:
+                self.statuses[nodeid] = STATUS_FAILED
+            elif report.skipped:
+                self.statuses[nodeid] = STATUS_SKIPPED
+            self._render(changed_nodeid=nodeid)
+            return
+
+        if report.when == "teardown" and report.failed:
+            self.statuses[nodeid] = STATUS_FAILED
+            self._render(changed_nodeid=nodeid)
+
+    def pytest_sessionfinish(self, session, exitstatus):
+        self._render(final=True)
+
+    def _summary(self) -> dict[str, int]:
+        counts = {
+            STATUS_PENDING: 0,
+            STATUS_RUNNING: 0,
+            STATUS_PASSED: 0,
+            STATUS_FAILED: 0,
+            STATUS_SKIPPED: 0,
+        }
+        for status in self.statuses.values():
+            counts[status] += 1
+        return counts
+
+    def _grouped_lines(self) -> list[str]:
+        groups: OrderedDict[str, list[str]] = OrderedDict()
+        for nodeid in self.nodeids:
+            groups.setdefault(scenario_name_from_nodeid(nodeid), []).append(nodeid)
+
+        lines: list[str] = []
+        for scenario, nodeids in groups.items():
+            lines.append(f"{scenario}")
+            for nodeid in nodeids:
+                lines.append(f"  {STATUS_ICON[self.statuses[nodeid]]} {short_name_from_nodeid(nodeid)}")
+        return lines
+
+    def _render(self, final: bool = False, changed_nodeid: str | None = None):
+        if not self.terminal_reporter or not self.nodeids:
+            return
+
+        summary = self._summary()
+        done = (
+            summary[STATUS_PASSED]
+            + summary[STATUS_FAILED]
+            + summary[STATUS_SKIPPED]
+        )
+        total = len(self.nodeids)
+        lines = [
+            "Suite Progress",
+            (
+                f"  done {done}/{total}  "
+                f"passed {summary[STATUS_PASSED]}  "
+                f"failed {summary[STATUS_FAILED]}  "
+                f"skipped {summary[STATUS_SKIPPED]}  "
+                f"running {summary[STATUS_RUNNING]}  "
+                f"pending {summary[STATUS_PENDING]}"
+            ),
+            "",
+            *self._grouped_lines(),
+        ]
+        output = "\n".join(lines)
+
+        if self.use_tty:
+            self.terminal_reporter.write("\x1b[2J\x1b[H" + output + ("\n" if final else ""), flush=True)
+        else:
+            if not self._listed_non_tty:
+                self.terminal_reporter.write_line(f"Collected {total} tests")
+                for line in self._grouped_lines():
+                    self.terminal_reporter.write_line(line)
+                self._listed_non_tty = True
+                return
+
+            if changed_nodeid is not None:
+                self.terminal_reporter.write_line(
+                    f"{STATUS_ICON[self.statuses[changed_nodeid]]} {changed_nodeid}"
+                )
+
+            if final:
+                self.terminal_reporter.write_line(
+                    (
+                        f"Summary: passed {summary[STATUS_PASSED]}, "
+                        f"failed {summary[STATUS_FAILED]}, "
+                        f"skipped {summary[STATUS_SKIPPED]}"
+                    )
+                )
+
+
+def build_pytest_args(args, passthrough: list[str]) -> list[str]:
+    pytest_args = [
+        "--rootdir",
+        str(SUITE_ROOT),
+    ]
+
+    if not args.show_logs:
+        pytest_args.extend(["-o", "log_cli=false"])
+
+    if args.list_only:
+        pytest_args.extend(["--collect-only", "-q"])
+    elif args.quiet:
+        pytest_args.append("-q")
+    else:
+        pytest_args.append("-vv")
+
+    pytest_args.extend(passthrough)
+
+    if not passthrough:
+        pytest_args.append("scenarios")
+
+    return pytest_args
+
+
+def print_collected_tests(nodeids: list[str]) -> None:
+    groups: OrderedDict[str, list[str]] = OrderedDict()
+    for nodeid in nodeids:
+        groups.setdefault(scenario_name_from_nodeid(nodeid), []).append(nodeid)
+
+    total = len(nodeids)
+    print(f"Collected {total} tests")
+    for scenario, scenario_tests in groups.items():
+        print()
+        print(f"{scenario} ({len(scenario_tests)})")
+        for nodeid in scenario_tests:
+            print(f"  [ ] {short_name_from_nodeid(nodeid)}")
+
+
+def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
+    parser = argparse.ArgumentParser(
+        description="List and run the Fluent Bit Python test suite with a simple checkbox progress view."
+    )
+    parser.add_argument("--list", dest="list_only", action="store_true", help="List collected tests and exit.")
+    parser.add_argument("--binary", help="Set FLUENT_BIT_BINARY for this run.")
+    parser.add_argument("--valgrind", action="store_true", help="Run with VALGRIND=1.")
+    parser.add_argument(
+        "--valgrind-strict",
+        action="store_true",
+        help="Run with VALGRIND=1 and VALGRIND_STRICT=1.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Use quieter pytest output; checkbox progress still renders.",
+    )
+    parser.add_argument(
+        "--show-logs",
+        action="store_true",
+        help="Keep pytest live logs enabled instead of the cleaner wrapper view.",
+    )
+    return parser.parse_known_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args, passthrough = parse_args(argv or sys.argv[1:])
+
+    os.chdir(SUITE_ROOT)
+
+    if args.binary:
+        os.environ["FLUENT_BIT_BINARY"] = args.binary
+    if args.valgrind or args.valgrind_strict:
+        os.environ["VALGRIND"] = "1"
+    if args.valgrind_strict:
+        os.environ["VALGRIND_STRICT"] = "1"
+
+    if args.list_only:
+        collector = CollectPlugin()
+        exit_code = pytest.main(build_pytest_args(args, passthrough), plugins=[collector])
+        if exit_code != 0:
+            return exit_code
+        print_collected_tests(collector.nodeids)
+        return 0
+
+    progress = CheckboxProgressPlugin()
+    return pytest.main(build_pytest_args(args, passthrough), plugins=[progress])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scenarios/in_elasticsearch/config/in_elasticsearch_http1_cleartext_small_buffer.yaml
+++ b/scenarios/in_elasticsearch/config/in_elasticsearch_http1_cleartext_small_buffer.yaml
@@ -1,0 +1,19 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: elasticsearch
+      listen: 0.0.0.0
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: off
+      tls: off
+      buffer_max_size: 112
+      buffer_chunk_size: 112
+
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/in_elasticsearch/config/in_elasticsearch_http1_cleartext_workers.yaml
+++ b/scenarios/in_elasticsearch/config/in_elasticsearch_http1_cleartext_workers.yaml
@@ -1,0 +1,18 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: elasticsearch
+      listen: 0.0.0.0
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: off
+      tls: off
+      http_server.workers: 4
+
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/in_elasticsearch/config/in_elasticsearch_http1_tls_workers.yaml
+++ b/scenarios/in_elasticsearch/config/in_elasticsearch_http1_tls_workers.yaml
@@ -1,0 +1,20 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: elasticsearch
+      listen: 0.0.0.0
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: off
+      tls: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+      http_server.workers: 4
+
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/in_elasticsearch/config/in_elasticsearch_http2_cleartext_small_buffer.yaml
+++ b/scenarios/in_elasticsearch/config/in_elasticsearch_http2_cleartext_small_buffer.yaml
@@ -1,0 +1,19 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: elasticsearch
+      listen: 0.0.0.0
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: on
+      tls: off
+      buffer_max_size: 112
+      buffer_chunk_size: 112
+
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/in_elasticsearch/config/in_elasticsearch_http2_cleartext_small_buffer_workers.yaml
+++ b/scenarios/in_elasticsearch/config/in_elasticsearch_http2_cleartext_small_buffer_workers.yaml
@@ -1,0 +1,20 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: elasticsearch
+      listen: 0.0.0.0
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: on
+      tls: off
+      http_server.workers: 4
+      buffer_max_size: 112
+      buffer_chunk_size: 112
+
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/in_elasticsearch/config/in_elasticsearch_http2_cleartext_workers.yaml
+++ b/scenarios/in_elasticsearch/config/in_elasticsearch_http2_cleartext_workers.yaml
@@ -1,0 +1,18 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: elasticsearch
+      listen: 0.0.0.0
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: on
+      tls: off
+      http_server.workers: 4
+
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/in_elasticsearch/config/in_elasticsearch_http2_tls_workers.yaml
+++ b/scenarios/in_elasticsearch/config/in_elasticsearch_http2_tls_workers.yaml
@@ -1,0 +1,20 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: elasticsearch
+      listen: 0.0.0.0
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: on
+      tls: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+      http_server.workers: 4
+
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/in_elasticsearch/tests/test_in_elasticsearch_001.py
+++ b/scenarios/in_elasticsearch/tests/test_in_elasticsearch_001.py
@@ -1,4 +1,4 @@
-import http.client, json, os, logging
+import http.client, json, os, logging, time, subprocess
 
 import pytest
 
@@ -9,11 +9,32 @@ from utils.test_service import FluentBitTestService
 logger = logging.getLogger(__name__)
 
 IN_ELASTICSEARCH_PROTOCOL_CONFIGS = {
-    "http1_cleartext": "in_elasticsearch_http1_cleartext.yaml",
-    "http2_cleartext": "in_elasticsearch_http2_cleartext.yaml",
-    "http1_tls": "in_elasticsearch_http1_tls.yaml",
-    "http2_tls": "in_elasticsearch_http2_tls.yaml",
+    False: {
+        "http1_cleartext": "in_elasticsearch_http1_cleartext.yaml",
+        "http2_cleartext": "in_elasticsearch_http2_cleartext.yaml",
+        "http1_tls": "in_elasticsearch_http1_tls.yaml",
+        "http2_tls": "in_elasticsearch_http2_tls.yaml",
+    },
+    True: {
+        "http1_cleartext": "in_elasticsearch_http1_cleartext_workers.yaml",
+        "http2_cleartext": "in_elasticsearch_http2_cleartext_workers.yaml",
+        "http1_tls": "in_elasticsearch_http1_tls_workers.yaml",
+        "http2_tls": "in_elasticsearch_http2_tls_workers.yaml",
+    },
 }
+
+IN_ELASTICSEARCH_SMALL_BUFFER_REGRESSION_CASES = [
+    {
+        "id": "legacy_http1_cleartext",
+        "config_file": "in_elasticsearch_http1_cleartext_small_buffer.yaml",
+        "http_mode": "http1.1",
+    },
+    {
+        "id": "http2_cleartext",
+        "config_file": "in_elasticsearch_http2_cleartext_small_buffer.yaml",
+        "http_mode": "http2-prior-knowledge",
+    },
+]
 
 
 def parse_single_item_response(response_text):
@@ -200,10 +221,13 @@ def test_in_elasticsearch_delete_multiple_documents():
         raise
 
 
+@pytest.mark.parametrize("workers_enabled", [False, True], ids=["single_listener", "workers_4"])
 @pytest.mark.parametrize("case", PROTOCOL_CASES, ids=[case["id"] for case in PROTOCOL_CASES])
-def test_in_elasticsearch_bulk_protocol_matrix(case):
-    service = Service(IN_ELASTICSEARCH_PROTOCOL_CONFIGS[case["config_key"]])
+def test_in_elasticsearch_bulk_protocol_matrix(case, workers_enabled):
+    service = Service(IN_ELASTICSEARCH_PROTOCOL_CONFIGS[workers_enabled][case["config_key"]])
     service.start()
+    if workers_enabled:
+        service.wait_for_log_message("with 4 workers", timeout=10)
 
     scheme = "https" if case["use_tls"] else "http"
     result = run_curl_request(
@@ -245,6 +269,66 @@ def test_in_elasticsearch_rejects_unknown_bulk_operation():
     assert details["status"] == 400
 
 
+@pytest.mark.parametrize(
+    "case",
+    IN_ELASTICSEARCH_SMALL_BUFFER_REGRESSION_CASES,
+    ids=[case["id"] for case in IN_ELASTICSEARCH_SMALL_BUFFER_REGRESSION_CASES],
+)
+def test_in_elasticsearch_bulk_small_status_buffer_does_not_crash(case):
+    service = Service(case["config_file"])
+    service.start()
+
+    trigger_payload = '{"index":{}}\n{}\n{"index":{}}\n{}\n'
+    curl_command = [
+        "curl",
+        "--silent",
+        "--show-error",
+        "--output",
+        "-",
+        "--write-out",
+        "\n__META__%{http_code} %{http_version}",
+        "--max-time",
+        "10",
+        "-X",
+        "POST",
+        "-H",
+        "Content-Type: application/x-ndjson",
+        "--data-binary",
+        "@-",
+    ]
+    if case["http_mode"] == "http2-prior-knowledge":
+        curl_command.append("--http2-prior-knowledge")
+    else:
+        curl_command.append("--http1.1")
+
+    curl_command.append(f"http://localhost:{service.flb_listener_port}/_bulk")
+
+    curl_result = subprocess.run(
+        curl_command,
+        input=trigger_payload.encode(),
+        capture_output=True,
+        check=False,
+    )
+
+    assert service.flb.process is not None
+    assert service.flb.process.poll() is None
+
+    health_result = run_curl_request(
+        f"http://localhost:{service.flb_listener_port}/_nodes/http",
+        None,
+        method="GET",
+        http_mode="http1.1",
+    )
+
+    service.stop()
+
+    # The regression condition is process termination from a reachable double-free.
+    # Response formatting can still vary under constrained buffer settings, but the
+    # parser must not take down the process.
+    assert curl_result.returncode in {0, 56}
+    assert health_result["status_code"] == 200
+
+
 class Service:
     def __init__(self, config_file):
         # Compose the absolute path for the Fluent Bit configuration file
@@ -267,6 +351,16 @@ class Service:
         self.service.start()
         self.flb = self.service.flb
         self.flb_listener_port = self.service.flb_listener_port
+
+    def wait_for_log_message(self, pattern, timeout=10, interval=0.25):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.flb and self.flb.log_file and os.path.exists(self.flb.log_file):
+                with open(self.flb.log_file, "r", encoding="utf-8", errors="replace") as log_file:
+                    if pattern in log_file.read():
+                        return True
+            time.sleep(interval)
+        raise TimeoutError(f"Timed out waiting for log pattern: {pattern}")
         self.test_suite_http_port = self.service.test_suite_http_port
         logger.info(f"Fluent Bit listener port: {self.flb_listener_port}")
         logger.info(f"test suite http port: {self.test_suite_http_port}")

--- a/scenarios/in_forward/config/in_forward.yaml
+++ b/scenarios/in_forward/config/in_forward.yaml
@@ -1,0 +1,20 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/scenarios/in_forward/config/in_forward_forced_tag.yaml
+++ b/scenarios/in_forward/config/in_forward_forced_tag.yaml
@@ -1,0 +1,21 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      tag: forced.tag
+
+  outputs:
+    - name: http
+      match: forced.tag
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/scenarios/in_forward/config/in_forward_secure.yaml
+++ b/scenarios/in_forward/config/in_forward_secure.yaml
@@ -1,0 +1,23 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      self_hostname: server-node
+      shared_key: shared-secret
+      security.users: alice s3cr3t
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/scenarios/in_forward/config/in_forward_storage_limit_multi_output.yaml
+++ b/scenarios/in_forward/config/in_forward_storage_limit_multi_output.yaml
@@ -1,0 +1,35 @@
+service:
+  flush: 60
+  grace: 5
+  log_level: info
+  storage.path: ${FORWARD_STORAGE_PATH}
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      storage.type: filesystem
+
+  outputs:
+    - name: http
+      match: shared.*
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /shared
+      format: json
+      json_date_key: false
+      retry_limit: false
+      storage.total_limit_size: 10M
+
+    - name: http
+      match: '*'
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /solo
+      format: json
+      json_date_key: false
+      retry_limit: false
+      storage.total_limit_size: 10K

--- a/scenarios/in_forward/config/in_forward_storage_limit_single_output.yaml
+++ b/scenarios/in_forward/config/in_forward_storage_limit_single_output.yaml
@@ -1,0 +1,25 @@
+service:
+  flush: 60
+  grace: 5
+  log_level: info
+  storage.path: ${FORWARD_STORAGE_PATH}
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      storage.type: filesystem
+
+  outputs:
+    - name: http
+      match: '*'
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /solo
+      format: json
+      json_date_key: false
+      retry_limit: false
+      storage.total_limit_size: 10K

--- a/scenarios/in_forward/config/in_forward_tag_prefix.yaml
+++ b/scenarios/in_forward/config/in_forward_tag_prefix.yaml
@@ -1,0 +1,21 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      tag_prefix: edge.
+
+  outputs:
+    - name: http
+      match: edge.*
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/scenarios/in_forward/config/in_forward_tls.yaml
+++ b/scenarios/in_forward/config/in_forward_tls.yaml
@@ -1,0 +1,23 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      tls: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/scenarios/in_forward/config/in_forward_to_forward_receiver.yaml
+++ b/scenarios/in_forward/config/in_forward_to_forward_receiver.yaml
@@ -1,0 +1,21 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: forward
+      match: test
+      host: 127.0.0.1
+      port: ${FORWARD_RECEIVER_PORT}
+      send_options: true
+      require_ack_response: true
+      retain_metadata_in_forward_mode: true

--- a/scenarios/in_forward/config/in_forward_to_forward_receiver_gzip.yaml
+++ b/scenarios/in_forward/config/in_forward_to_forward_receiver_gzip.yaml
@@ -1,0 +1,22 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: forward
+      match: test
+      host: 127.0.0.1
+      port: ${FORWARD_RECEIVER_PORT}
+      send_options: true
+      require_ack_response: true
+      retain_metadata_in_forward_mode: true
+      compress: gzip

--- a/scenarios/in_forward/config/in_forward_unix.yaml
+++ b/scenarios/in_forward/config/in_forward_unix.yaml
@@ -1,0 +1,19 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      unix_path: ${FORWARD_UNIX_PATH}
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/scenarios/in_forward/config/in_forward_unix_perm.yaml
+++ b/scenarios/in_forward/config/in_forward_unix_perm.yaml
@@ -1,0 +1,20 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: forward
+      unix_path: ${FORWARD_UNIX_PATH}
+      unix_perm: "0600"
+
+  outputs:
+    - name: http
+      match: test
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/scenarios/in_forward/config/in_opentelemetry_to_forward_receiver.yaml
+++ b/scenarios/in_forward/config/in_opentelemetry_to_forward_receiver.yaml
@@ -1,0 +1,20 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: off
+      tls: off
+
+  outputs:
+    - name: forward
+      match: '*'
+      host: 127.0.0.1
+      port: ${FORWARD_RECEIVER_PORT}
+      send_options: true
+      require_ack_response: true

--- a/scenarios/in_forward/tests/test_in_forward_001.py
+++ b/scenarios/in_forward/tests/test_in_forward_001.py
@@ -1,0 +1,991 @@
+import gzip
+import hashlib
+import json
+import os
+import shutil
+import socket
+import ssl
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
+
+import pytest
+import requests
+from google.protobuf import json_format
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+from server.forward_server import (
+    data_storage as forward_data_storage,
+    forward_server_run,
+    forward_server_stop,
+)
+from server.http_server import configure_http_response, data_storage, http_server_run
+from utils.data_utils import read_json_file
+from utils.test_service import FluentBitTestService
+
+
+TEST_TAG = "test"
+TEST_TS = 1234567890
+SECURE_SHARED_KEY = "shared-secret"
+SECURE_USERNAME = "alice"
+SECURE_PASSWORD = "s3cr3t"
+SECURE_SELF_HOSTNAME = "server-node"
+
+
+class Service:
+    def __init__(self, config_file, *, use_unix_socket=False):
+        self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
+        self.use_unix_socket = use_unix_socket
+        self.socket_path = None
+        test_path = os.path.dirname(os.path.abspath(__file__))
+        cert_dir = os.path.abspath(os.path.join(test_path, "../../in_splunk/certificate"))
+        self.tls_crt_file = os.path.join(cert_dir, "certificate.pem")
+        self.tls_key_file = os.path.join(cert_dir, "private_key.pem")
+        extra_env = {
+            "CERTIFICATE_TEST": self.tls_crt_file,
+            "PRIVATE_KEY_TEST": self.tls_key_file,
+        }
+
+        if use_unix_socket:
+            self.socket_path = os.path.join(tempfile.gettempdir(), f"fluent_bit_forward_{uuid.uuid4().hex}.sock")
+            extra_env["FORWARD_UNIX_PATH"] = self.socket_path
+
+        self.service = FluentBitTestService(
+            self.config_file,
+            data_storage=data_storage,
+            data_keys=["payloads"],
+            extra_env=extra_env,
+            pre_start=self._start_receiver,
+            post_stop=self._stop_receiver,
+        )
+
+    def _start_receiver(self, service):
+        http_server_run(service.test_suite_http_port)
+        self.service.wait_for_http_endpoint(
+            f"http://127.0.0.1:{service.test_suite_http_port}/ping",
+            timeout=10,
+            interval=0.5,
+        )
+
+    def _stop_receiver(self, service):
+        try:
+            requests.post(f"http://127.0.0.1:{service.test_suite_http_port}/shutdown", timeout=2)
+        except requests.RequestException:
+            pass
+        if self.socket_path:
+            try:
+                os.unlink(self.socket_path)
+            except FileNotFoundError:
+                pass
+
+    def start(self):
+        self.service.start()
+        self.flb_listener_port = self.service.flb_listener_port
+
+    def stop(self):
+        self.service.stop()
+
+    def flattened_records(self):
+        records = []
+        for payload in data_storage["payloads"]:
+            if isinstance(payload, list):
+                records.extend(payload)
+            elif payload is not None:
+                records.append(payload)
+        return records
+
+    def wait_for_record_count(self, minimum_count, timeout=10):
+        return self.service.wait_for_condition(
+            lambda: self.flattened_records() if len(self.flattened_records()) >= minimum_count else None,
+            timeout=timeout,
+            interval=0.2,
+            description=f"{minimum_count} forwarded forward records",
+        )
+
+
+class StorageLimitService(Service):
+    def __init__(self, config_file):
+        super().__init__(config_file)
+        self.storage_path = tempfile.mkdtemp(prefix="fluent_bit_forward_storage_")
+        self.service.extra_env["FORWARD_STORAGE_PATH"] = self.storage_path
+
+    def stop(self):
+        try:
+            super().stop()
+        finally:
+            shutil.rmtree(self.storage_path, ignore_errors=True)
+
+    def count_chunk_files(self):
+        stream_dir = Path(self.storage_path) / "forward.0"
+        if not stream_dir.exists():
+            return 0
+
+        return sum(1 for path in stream_dir.rglob("*.flb") if path.is_file())
+
+    def chunk_file_contents(self):
+        stream_dir = Path(self.storage_path) / "forward.0"
+        if not stream_dir.exists():
+            return []
+
+        return [path.read_bytes() for path in stream_dir.rglob("*.flb") if path.is_file()]
+
+
+class ForwardReceiverService:
+    def __init__(self, config_file):
+        self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
+        self.service = FluentBitTestService(
+            self.config_file,
+            pre_start=self._start_receiver,
+            post_stop=self._stop_receiver,
+        )
+
+    def _start_receiver(self, service):
+        self.forward_receiver_port = service.allocate_port_env("FORWARD_RECEIVER_PORT")
+        forward_server_run(self.forward_receiver_port)
+
+    def _stop_receiver(self, service):
+        forward_server_stop()
+
+    def start(self):
+        self.service.start()
+        self.flb_listener_port = self.service.flb_listener_port
+
+    def stop(self):
+        self.service.stop()
+
+    def wait_for_forward_messages(self, minimum_count, timeout=10):
+        return self.service.wait_for_condition(
+            lambda: forward_data_storage["messages"] if len(forward_data_storage["messages"]) >= minimum_count else None,
+            timeout=timeout,
+            interval=0.2,
+            description=f"{minimum_count} captured forward messages",
+        )
+
+    def send_request(self, endpoint, payload, content_type="application/x-protobuf"):
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}{endpoint}",
+            data=payload.SerializeToString(),
+            headers={"Content-Type": content_type},
+            timeout=5,
+        )
+        response.raise_for_status()
+        return response
+
+    def send_json_as_otel_protobuf(self, json_input, signal_type):
+        base_path = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../../in_opentelemetry/tests/data_files",
+            )
+        )
+        json_payload_dict = read_json_file(os.path.join(base_path, json_input))
+        request_map = {
+            "metrics": (ExportMetricsServiceRequest(), "/v1/metrics"),
+            "traces": (ExportTraceServiceRequest(), "/v1/traces"),
+        }
+        request_message, endpoint = request_map[signal_type]
+        protobuf_payload = json_format.Parse(json.dumps(json_payload_dict), request_message)
+        return self.send_request(endpoint, protobuf_payload)
+
+
+def _pack_uint(value):
+    if value < 0x80:
+        return bytes([value])
+    if value <= 0xFF:
+        return b"\xCC" + bytes([value])
+    if value <= 0xFFFF:
+        return b"\xCD" + value.to_bytes(2, "big")
+    if value <= 0xFFFFFFFF:
+        return b"\xCE" + value.to_bytes(4, "big")
+    return b"\xCF" + value.to_bytes(8, "big")
+
+
+def _pack_bool(value):
+    return b"\xC3" if value else b"\xC2"
+
+
+def _pack_str(value):
+    data = value.encode()
+    length = len(data)
+    if length <= 31:
+        return bytes([0xA0 | length]) + data
+    if length <= 0xFF:
+        return b"\xD9" + bytes([length]) + data
+    if length <= 0xFFFF:
+        return b"\xDA" + length.to_bytes(2, "big") + data
+    return b"\xDB" + length.to_bytes(4, "big") + data
+
+
+def _pack_bin(value):
+    length = len(value)
+    if length <= 0xFF:
+        return b"\xC4" + bytes([length]) + value
+    if length <= 0xFFFF:
+        return b"\xC5" + length.to_bytes(2, "big") + value
+    return b"\xC6" + length.to_bytes(4, "big") + value
+
+
+def _pack_ext(type_code, payload):
+    length = len(payload)
+    if length == 1:
+        return b"\xD4" + type_code.to_bytes(1, "big", signed=True) + payload
+    if length == 2:
+        return b"\xD5" + type_code.to_bytes(1, "big", signed=True) + payload
+    if length == 4:
+        return b"\xD6" + type_code.to_bytes(1, "big", signed=True) + payload
+    if length == 8:
+        return b"\xD7" + type_code.to_bytes(1, "big", signed=True) + payload
+    if length == 16:
+        return b"\xD8" + type_code.to_bytes(1, "big", signed=True) + payload
+    raise ValueError(f"Unsupported ext payload size {length}")
+
+
+def _pack_array(items):
+    length = len(items)
+    if length <= 15:
+        prefix = bytes([0x90 | length])
+    elif length <= 0xFFFF:
+        prefix = b"\xDC" + length.to_bytes(2, "big")
+    else:
+        prefix = b"\xDD" + length.to_bytes(4, "big")
+    return prefix + b"".join(_pack_obj(item) for item in items)
+
+
+def _pack_map(mapping):
+    items = list(mapping.items())
+    length = len(items)
+    if length <= 15:
+        prefix = bytes([0x80 | length])
+    elif length <= 0xFFFF:
+        prefix = b"\xDE" + length.to_bytes(2, "big")
+    else:
+        prefix = b"\xDF" + length.to_bytes(4, "big")
+    encoded = []
+    for key, value in items:
+        encoded.append(_pack_obj(key))
+        encoded.append(_pack_obj(value))
+    return prefix + b"".join(encoded)
+
+
+def _pack_obj(value):
+    if value is None:
+        return b"\xC0"
+    if value is False:
+        return b"\xC2"
+    if value is True:
+        return b"\xC3"
+    if isinstance(value, int):
+        return _pack_uint(value)
+    if isinstance(value, bool):
+        return _pack_bool(value)
+    if isinstance(value, str):
+        return _pack_str(value)
+    if isinstance(value, bytes):
+        return _pack_bin(value)
+    if isinstance(value, tuple) and len(value) == 3 and value[0] == "__ext__":
+        return _pack_ext(value[1], value[2])
+    if isinstance(value, list):
+        return _pack_array(value)
+    if isinstance(value, dict):
+        return _pack_map(value)
+    raise TypeError(f"Unsupported value type {type(value)!r}")
+
+
+def _message_mode_payload(tag, body):
+    return _pack_obj([tag, TEST_TS, body])
+
+
+def _message_mode_eventtime_payload(tag, body, *, seconds, nanoseconds):
+    ext_payload = seconds.to_bytes(4, "big") + nanoseconds.to_bytes(4, "big")
+    return _pack_obj([tag, ("__ext__", 0, ext_payload), body])
+
+
+def _forward_mode_payload(tag, entries):
+    return _pack_obj([tag, [[TEST_TS, entry] for entry in entries]])
+
+
+def _packed_forward_payload(tag, packed_entries, *, compressed=None):
+    options = {}
+    if compressed:
+        options["compressed"] = compressed
+    payload = [tag, packed_entries]
+    if options:
+        payload.append(options)
+    return _pack_obj(payload)
+
+
+def _gzip_bytes(data):
+    return gzip.compress(data)
+
+
+def _zstd_bytes(data):
+    if not shutil.which("zstd"):
+        pytest.skip("zstd binary is required for this test")
+
+    result = subprocess.run(
+        ["zstd", "-q", "-c"],
+        input=data,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _send_tcp_payload(port, payload):
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+        sock.sendall(payload)
+
+
+def _send_unix_payload(path, payload):
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+        sock.settimeout(5)
+        sock.connect(path)
+        sock.sendall(payload)
+
+
+def _send_tls_payload(port, payload, cafile):
+    context = ssl.create_default_context(cafile=cafile)
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as raw_sock:
+        with context.wrap_socket(raw_sock, server_hostname="localhost") as tls_sock:
+            tls_sock.sendall(payload)
+
+
+def _recv_msgpack_value(sock):
+    sock.settimeout(5)
+    data = sock.recv(4096)
+    assert data
+    value, offset = _unpack_obj(data, 0)
+    assert offset == len(data)
+    return value
+
+
+def _decode_str_like(raw):
+    try:
+        return raw.decode()
+    except UnicodeDecodeError:
+        return raw
+
+
+def _unpack_obj(data, offset):
+    first = data[offset]
+    offset += 1
+
+    if first <= 0x7F:
+        return first, offset
+    if 0x80 <= first <= 0x8F:
+        size = first & 0x0F
+        result = {}
+        for _ in range(size):
+            key, offset = _unpack_obj(data, offset)
+            value, offset = _unpack_obj(data, offset)
+            result[key] = value
+        return result, offset
+    if 0x90 <= first <= 0x9F:
+        size = first & 0x0F
+        result = []
+        for _ in range(size):
+            value, offset = _unpack_obj(data, offset)
+            result.append(value)
+        return result, offset
+    if 0xA0 <= first <= 0xBF:
+        size = first & 0x1F
+        raw = data[offset:offset + size]
+        return _decode_str_like(raw), offset + size
+    if first == 0xC0:
+        return None, offset
+    if first == 0xC2:
+        return False, offset
+    if first == 0xC3:
+        return True, offset
+    if first == 0xC4:
+        size = data[offset]
+        offset += 1
+        return data[offset:offset + size], offset + size
+    if first == 0xCC:
+        return data[offset], offset + 1
+    if first == 0xCD:
+        return int.from_bytes(data[offset:offset + 2], "big"), offset + 2
+    if first == 0xCE:
+        return int.from_bytes(data[offset:offset + 4], "big"), offset + 4
+    if first == 0xCF:
+        return int.from_bytes(data[offset:offset + 8], "big"), offset + 8
+    if first == 0xD9:
+        size = data[offset]
+        offset += 1
+        raw = data[offset:offset + size]
+        return _decode_str_like(raw), offset + size
+    if first == 0xDA:
+        size = int.from_bytes(data[offset:offset + 2], "big")
+        offset += 2
+        raw = data[offset:offset + size]
+        return _decode_str_like(raw), offset + size
+    if first == 0xDE:
+        size = int.from_bytes(data[offset:offset + 2], "big")
+        offset += 2
+        result = {}
+        for _ in range(size):
+            key, offset = _unpack_obj(data, offset)
+            value, offset = _unpack_obj(data, offset)
+            result[key] = value
+        return result, offset
+
+    raise ValueError(f"Unsupported MessagePack type 0x{first:02x}")
+
+
+def _sha512_hex(*parts):
+    hasher = hashlib.sha512()
+    for part in parts:
+        if isinstance(part, str):
+            part = part.encode()
+        hasher.update(part)
+    return hasher.hexdigest()
+
+
+def _secure_forward_handshake(sock, *, username, password, shared_key, hostname="client-node", shared_key_salt="client-salt-1234"):
+    helo = _recv_msgpack_value(sock)
+    assert helo[0] == "HELO"
+
+    helo_options = helo[1]
+    nonce = helo_options["nonce"]
+    auth_salt = helo_options["auth"]
+
+    shared_key_digest = _sha512_hex(shared_key_salt, hostname, nonce, shared_key)
+    password_digest = _sha512_hex(auth_salt, username, password)
+
+    ping = _pack_obj(["PING", hostname, shared_key_salt, shared_key_digest, username, password_digest])
+    sock.sendall(ping)
+
+    return _recv_msgpack_value(sock)
+
+
+def test_in_forward_message_mode_tcp():
+    service = Service("in_forward.yaml")
+    service.start()
+
+    try:
+        payload = _message_mode_payload(TEST_TAG, {"message": "message-mode"})
+        _send_tcp_payload(service.flb_listener_port, payload)
+        records = service.wait_for_record_count(1)
+    finally:
+        service.stop()
+
+    assert records[0]["message"] == "message-mode"
+
+
+def test_in_forward_message_mode_partial_tcp_writes():
+    service = Service("in_forward.yaml")
+    service.start()
+
+    try:
+        payload = _message_mode_payload(TEST_TAG, {"message": "partial"})
+        midpoint = len(payload) // 2
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as sock:
+            sock.sendall(payload[:midpoint])
+            sock.sendall(payload[midpoint:])
+        records = service.wait_for_record_count(1)
+    finally:
+        service.stop()
+
+    assert records[0]["message"] == "partial"
+
+
+def test_in_forward_message_mode_eventtime_ext():
+    service = Service("in_forward.yaml")
+    service.start()
+
+    try:
+        payload = _message_mode_eventtime_payload(
+            TEST_TAG,
+            {"message": "eventtime"},
+            seconds=TEST_TS,
+            nanoseconds=123456789,
+        )
+        _send_tcp_payload(service.flb_listener_port, payload)
+        records = service.wait_for_record_count(1)
+    finally:
+        service.stop()
+
+    assert records[0]["message"] == "eventtime"
+
+
+def test_in_forward_forward_mode_multiple_entries():
+    service = Service("in_forward.yaml")
+    service.start()
+
+    try:
+        payload = _forward_mode_payload(TEST_TAG, [{"message": "entry-1"}, {"message": "entry-2"}])
+        _send_tcp_payload(service.flb_listener_port, payload)
+        records = service.wait_for_record_count(2)
+    finally:
+        service.stop()
+
+    assert [record["message"] for record in records[:2]] == ["entry-1", "entry-2"]
+
+
+def test_in_forward_packed_forward_gzip():
+    service = Service("in_forward.yaml")
+    service.start()
+
+    try:
+        packed_entries = _pack_obj([TEST_TS, {"message": "gzip-packed-forward"}])
+        payload = _packed_forward_payload(TEST_TAG, _gzip_bytes(packed_entries), compressed="gzip")
+        _send_tcp_payload(service.flb_listener_port, payload)
+        records = service.wait_for_record_count(1)
+    finally:
+        service.stop()
+
+    assert records[0]["message"] == "gzip-packed-forward"
+
+
+def test_in_forward_packed_forward_uncompressed_with_ack():
+    service = Service("in_forward.yaml")
+    service.start()
+
+    try:
+        chunk = "packed-chunk-001"
+        packed_entries = _pack_obj([TEST_TS, {"message": "packed-uncompressed"}])
+        payload = _packed_forward_payload(TEST_TAG, packed_entries, compressed=None)
+        payload = _pack_obj([TEST_TAG, packed_entries, {"chunk": chunk}])
+
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as sock:
+            sock.sendall(payload)
+            ack = _recv_msgpack_value(sock)
+
+        records = service.wait_for_record_count(1)
+    finally:
+        service.stop()
+
+    assert ack == {"ack": chunk}
+    assert records[0]["message"] == "packed-uncompressed"
+
+
+def test_in_forward_packed_forward_zstd():
+    service = Service("in_forward.yaml")
+    service.start()
+
+    try:
+        packed_entries = _pack_obj([TEST_TS, {"message": "zstd-packed-forward"}])
+        payload = _packed_forward_payload(TEST_TAG, _zstd_bytes(packed_entries), compressed="zstd")
+        _send_tcp_payload(service.flb_listener_port, payload)
+        records = service.wait_for_record_count(1)
+    finally:
+        service.stop()
+
+    assert records[0]["message"] == "zstd-packed-forward"
+
+
+def test_in_forward_message_mode_chunk_ack_and_metadata():
+    service = Service("in_forward.yaml")
+    service.start()
+
+    try:
+        chunk = "chunk-001"
+        payload = _pack_obj(
+            [
+                TEST_TAG,
+                TEST_TS,
+                {"message": "metadata-ack"},
+                {"chunk": chunk, "metadata": {"source": "suite", "path": "message-mode"}},
+            ]
+        )
+
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as sock:
+            sock.sendall(payload)
+            ack = _recv_msgpack_value(sock)
+
+        records = service.wait_for_record_count(1)
+    finally:
+        service.stop()
+
+    assert ack == {"ack": chunk}
+    assert records[0]["message"] == "metadata-ack"
+
+
+def test_in_forward_forward_mode_chunk_ack():
+    service = Service("in_forward.yaml")
+    service.start()
+
+    try:
+        chunk = "forward-chunk-001"
+        payload = _pack_obj(
+            [
+                TEST_TAG,
+                [[TEST_TS, {"message": "forward-ack"}]],
+                {"chunk": chunk},
+            ]
+        )
+
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as sock:
+            sock.sendall(payload)
+            ack = _recv_msgpack_value(sock)
+
+        records = service.wait_for_record_count(1)
+    finally:
+        service.stop()
+
+    assert ack == {"ack": chunk}
+    assert records[0]["message"] == "forward-ack"
+
+
+def test_in_forward_tag_prefix_routes_records():
+    service = Service("in_forward_tag_prefix.yaml")
+    service.start()
+
+    try:
+        payload = _message_mode_payload(TEST_TAG, {"message": "prefixed"})
+        _send_tcp_payload(service.flb_listener_port, payload)
+        records = service.wait_for_record_count(1)
+    finally:
+        service.stop()
+
+    assert records[0]["message"] == "prefixed"
+
+
+def test_in_forward_forced_input_tag_overrides_incoming_tag():
+    service = Service("in_forward_forced_tag.yaml")
+    service.start()
+
+    try:
+        payload = _message_mode_payload("ignored.incoming.tag", {"message": "forced-tag"})
+        _send_tcp_payload(service.flb_listener_port, payload)
+        records = service.wait_for_record_count(1)
+    finally:
+        service.stop()
+
+    assert records[0]["message"] == "forced-tag"
+
+
+def test_in_forward_unix_socket_message_mode():
+    service = Service("in_forward_unix.yaml", use_unix_socket=True)
+    service.start()
+
+    try:
+        service.service.wait_for_condition(
+            lambda: os.path.exists(service.socket_path),
+            timeout=10,
+            interval=0.2,
+            description="forward unix socket",
+        )
+        payload = _message_mode_payload(TEST_TAG, {"message": "unix-socket"})
+        _send_unix_payload(service.socket_path, payload)
+        records = service.wait_for_record_count(1)
+    finally:
+        service.stop()
+
+    assert records[0]["message"] == "unix-socket"
+
+
+def test_in_forward_unix_socket_permissions():
+    service = Service("in_forward_unix_perm.yaml", use_unix_socket=True)
+    service.start()
+
+    try:
+        service.service.wait_for_condition(
+            lambda: os.path.exists(service.socket_path),
+            timeout=10,
+            interval=0.2,
+            description="forward unix socket with permissions",
+        )
+        mode = os.stat(service.socket_path).st_mode & 0o777
+    finally:
+        service.stop()
+
+    assert mode == 0o600
+
+
+def test_in_forward_tls_message_mode():
+    service = Service("in_forward_tls.yaml")
+    service.start()
+
+    try:
+        payload = _message_mode_payload(TEST_TAG, {"message": "tls-message"})
+        _send_tls_payload(service.flb_listener_port, payload, service.tls_crt_file)
+        records = service.wait_for_record_count(1)
+    finally:
+        service.stop()
+
+    assert records[0]["message"] == "tls-message"
+
+
+def test_in_forward_secure_forward_auth_success():
+    service = Service("in_forward_secure.yaml")
+    service.start()
+
+    try:
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as sock:
+            pong = _secure_forward_handshake(
+                sock,
+                username=SECURE_USERNAME,
+                password=SECURE_PASSWORD,
+                shared_key=SECURE_SHARED_KEY,
+            )
+            sock.sendall(_message_mode_payload(TEST_TAG, {"message": "secure-success"}))
+
+        records = service.wait_for_record_count(1)
+    finally:
+        service.stop()
+
+    assert pong[0] == "PONG"
+    assert pong[1] is True
+    assert pong[2] == ""
+    assert pong[3] == SECURE_SELF_HOSTNAME
+    assert records[0]["message"] == "secure-success"
+
+
+def test_in_forward_secure_forward_auth_failure():
+    service = Service("in_forward_secure.yaml")
+    service.start()
+
+    try:
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as sock:
+            pong = _secure_forward_handshake(
+                sock,
+                username=SECURE_USERNAME,
+                password="wrong-password",
+                shared_key=SECURE_SHARED_KEY,
+            )
+            sock.sendall(_message_mode_payload(TEST_TAG, {"message": "should-not-pass"}))
+
+        with pytest.raises(TimeoutError):
+            service.wait_for_record_count(1, timeout=2)
+    finally:
+        service.stop()
+
+    assert pong[0] == "PONG"
+    assert pong[1] is False
+    assert "username/password mismatch" in pong[2]
+
+
+def test_in_forward_e2e_forward_receiver_preserves_metadata_and_signal_options():
+    service = ForwardReceiverService("in_forward_to_forward_receiver.yaml")
+    service.start()
+
+    try:
+        payload = _pack_obj(
+            [
+                TEST_TAG,
+                TEST_TS,
+                {"message": "end-to-end-forward"},
+                {"metadata": {"source": "suite", "scope": "log"}, "chunk": "input-chunk"},
+            ]
+        )
+        _send_tcp_payload(service.flb_listener_port, payload)
+        messages = service.wait_for_forward_messages(1)
+    finally:
+        service.stop()
+
+    message = messages[0]
+    record = message["records"][0]
+    raw_record = record["raw"]
+
+    assert message["mode"] == "forward"
+    assert message["tag"] == TEST_TAG
+    assert message["options"]["fluent_signal"] == 0
+    assert message["options"]["size"] == 1
+    assert message["options"]["chunk"]
+    assert "metadata" not in message["options"]
+    assert len(raw_record) == 2
+    assert len(raw_record[0]) == 2
+    assert raw_record[0][1] == {"source": "suite", "scope": "log"}
+    assert record["body"]["message"] == "end-to-end-forward"
+    assert record["metadata"]["source"] == "suite"
+    assert record["metadata"]["scope"] == "log"
+
+
+def test_in_forward_e2e_forward_receiver_gzip_preserves_metadata_and_signal_options():
+    service = ForwardReceiverService("in_forward_to_forward_receiver_gzip.yaml")
+    service.start()
+
+    try:
+        payload = _pack_obj(
+            [
+                TEST_TAG,
+                TEST_TS,
+                {"message": "end-to-end-gzip"},
+                {"metadata": {"source": "suite", "scope": "gzip"}, "chunk": "input-chunk-gzip"},
+            ]
+        )
+        _send_tcp_payload(service.flb_listener_port, payload)
+        messages = service.wait_for_forward_messages(1)
+    finally:
+        service.stop()
+
+    message = messages[0]
+    record = message["records"][0]
+    raw_record = record["raw"]
+
+    assert message["mode"] == "packed_forward"
+    assert message["tag"] == TEST_TAG
+    assert message["options"]["compressed"] == "gzip"
+    assert message["options"]["fluent_signal"] == 0
+    assert message["options"]["size"] == 1
+    assert message["options"]["chunk"]
+    assert "metadata" not in message["options"]
+    assert len(raw_record) == 2
+    assert len(raw_record[0]) == 2
+    assert raw_record[0][1] == {"source": "suite", "scope": "gzip"}
+    assert record["body"]["message"] == "end-to-end-gzip"
+    assert record["metadata"]["source"] == "suite"
+    assert record["metadata"]["scope"] == "gzip"
+
+
+def test_out_forward_metrics_signal_e2e_with_forward_receiver():
+    service = ForwardReceiverService("in_opentelemetry_to_forward_receiver.yaml")
+    service.start()
+
+    try:
+        service.send_json_as_otel_protobuf("test_metrics_001.in.json", "metrics")
+        messages = service.wait_for_forward_messages(1)
+    finally:
+        service.stop()
+
+    message = messages[0]
+    record_payload = message["records"][0]["raw"]
+
+    assert message["mode"] == "packed_forward"
+    assert message["tag"] == "v1_metrics"
+    assert message["options"]["fluent_signal"] == 1
+    assert message["options"]["chunk"]
+    assert "size" not in message["options"]
+    assert len(message["records"]) >= 1
+    assert record_payload["meta"]["external"]["scope"]["metadata"]["name"] == "metrics-scope"
+    assert record_payload["metrics"][0]["meta"]["opts"]["name"] == "requests_total"
+    assert record_payload["metrics"][0]["values"][0]["labels"] == ["checkout"]
+    assert record_payload["metrics"][0]["values"][0]["value_int64"] == 42
+
+
+def test_out_forward_traces_signal_e2e_with_forward_receiver():
+    service = ForwardReceiverService("in_opentelemetry_to_forward_receiver.yaml")
+    service.start()
+
+    try:
+        service.send_json_as_otel_protobuf("test_traces_001.in.json", "traces")
+        messages = service.wait_for_forward_messages(1)
+    finally:
+        service.stop()
+
+    message = messages[0]
+    record_payload = message["records"][0]["raw"]
+
+    assert message["mode"] == "packed_forward"
+    assert message["tag"] == "v1_traces"
+    assert message["options"]["fluent_signal"] == 2
+    assert message["options"]["chunk"]
+    assert "size" not in message["options"]
+    assert len(message["records"]) >= 1
+    span = record_payload["resourceSpans"][0]["scope_spans"][0]["spans"][0]
+    assert record_payload["resourceSpans"][0]["scope_spans"][0]["scope"]["name"] == "trace-scope"
+    assert record_payload["resourceSpans"][0]["resource"]["attributes"]["service.name"] == "checkout"
+    assert span["name"] == "checkout-span"
+    assert span["attributes"]["http.method"] == "GET"
+
+
+def test_in_forward_storage_limit_single_output_prefers_actual_chunk_deletion():
+    service = StorageLimitService("in_forward_storage_limit_single_output.yaml")
+    service.start()
+
+    try:
+        configure_http_response(status_code=500, body={"status": "retry"})
+
+        _send_tcp_payload(service.flb_listener_port, _message_mode_payload("solo.one", {"message": "single-one"}))
+        _send_tcp_payload(service.flb_listener_port, _message_mode_payload("solo.two", {"message": "single-two"}))
+
+        service.service.wait_for_condition(
+            lambda: service.count_chunk_files() == 2,
+            timeout=10,
+            interval=0.2,
+            description="2 chunk files after two solo messages",
+        )
+
+        _send_tcp_payload(service.flb_listener_port, _message_mode_payload("solo.three", {"message": "single-three"}))
+
+        def single_output_eviction_snapshot():
+            chunk_contents = service.chunk_file_contents()
+
+            if len(chunk_contents) != 2:
+                return None
+
+            if any(b"solo.one" in content for content in chunk_contents):
+                return None
+
+            if not any(b"solo.three" in content for content in chunk_contents):
+                return None
+
+            return chunk_contents
+
+        try:
+            chunk_contents = service.service.wait_for_condition(
+                single_output_eviction_snapshot,
+                timeout=10,
+                interval=0.2,
+                description="single-output storage eviction snapshot",
+            )
+        except TimeoutError:
+            if service.count_chunk_files() >= 3:
+                pytest.skip(
+                    "forward storage eviction preference is not supported by this Fluent Bit binary"
+                )
+            raise
+    finally:
+        service.stop()
+
+    assert not any(b"solo.one" in content for content in chunk_contents)
+    assert any(b"solo.three" in content for content in chunk_contents)
+
+
+def test_in_forward_storage_limit_multi_output_prefers_deletable_solo_chunk():
+    service = StorageLimitService("in_forward_storage_limit_multi_output.yaml")
+    service.start()
+
+    try:
+        configure_http_response(status_code=500, body={"status": "retry"})
+
+        _send_tcp_payload(service.flb_listener_port, _message_mode_payload("shared.one", {"message": "shared-one"}))
+        _send_tcp_payload(service.flb_listener_port, _message_mode_payload("solo.one", {"message": "solo-one"}))
+
+        service.service.wait_for_condition(
+            lambda: service.count_chunk_files() == 2,
+            timeout=10,
+            interval=0.2,
+            description="2 chunk files after shared and solo messages",
+        )
+
+        _send_tcp_payload(service.flb_listener_port, _message_mode_payload("solo.two", {"message": "solo-two"}))
+
+        def multi_output_eviction_snapshot():
+            chunk_contents = service.chunk_file_contents()
+
+            if len(chunk_contents) != 2:
+                return None
+
+            if any(b"solo.one" in content for content in chunk_contents):
+                return None
+
+            if not any(b"shared.one" in content for content in chunk_contents):
+                return None
+
+            if not any(b"solo.two" in content for content in chunk_contents):
+                return None
+
+            return chunk_contents
+
+        try:
+            chunk_contents = service.service.wait_for_condition(
+                multi_output_eviction_snapshot,
+                timeout=10,
+                interval=0.2,
+                description="multi-output storage eviction snapshot",
+            )
+        except TimeoutError:
+            if service.count_chunk_files() >= 3:
+                pytest.skip(
+                    "forward storage eviction preference is not supported by this Fluent Bit binary"
+                )
+            raise
+    finally:
+        service.stop()
+
+    assert any(b"shared.one" in content for content in chunk_contents)
+    assert not any(b"solo.one" in content for content in chunk_contents)

--- a/scenarios/in_mqtt/config/in_mqtt.yaml
+++ b/scenarios/in_mqtt/config/in_mqtt.yaml
@@ -1,0 +1,21 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: mqtt
+      tag: target_input
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: http
+      match: target_input
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/scenarios/in_mqtt/config/in_mqtt_payload_key.yaml
+++ b/scenarios/in_mqtt/config/in_mqtt_payload_key.yaml
@@ -1,0 +1,22 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: mqtt
+      tag: target_input
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      payload_key: payload_k
+
+  outputs:
+    - name: http
+      match: target_input
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      uri: /data
+      format: json

--- a/scenarios/in_mqtt/tests/test_in_mqtt_001.py
+++ b/scenarios/in_mqtt/tests/test_in_mqtt_001.py
@@ -1,0 +1,227 @@
+import os
+import socket
+import time
+
+import requests
+
+from server.http_server import data_storage, http_server_run
+from utils.test_service import FluentBitTestService
+
+
+MQTT_CONNECT_PACKET = bytes(
+    [0x10, 0x0A, 0x00, 0x04, ord("M"), ord("Q"), ord("T"), ord("T"), 0x04, 0xCE, 0x00, 0x0A]
+)
+MQTT_TRUNCATED_QOS1_PUBLISH_PACKET = bytes([0x32, 0x04, 0x00, 0x01, ord("X"), 0x00])
+MQTT_EMPTY_PUBLISH_PACKET = bytes([0x30, 0x03, 0x00, 0x01, ord("a")])
+MQTT_INVALID_TOPIC_LENGTH_PACKET = bytes([0x30, 0x04, 0x00, 0x05, ord("a"), ord("b")])
+MQTT_VALID_PAYLOAD = b'{"key":"val"}'
+MQTT_INVALID_JSON_PAYLOAD = b'{"key"'
+
+
+class Service:
+    def __init__(self, config_file="in_mqtt.yaml"):
+        self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
+        self.service = FluentBitTestService(
+            self.config_file,
+            data_storage=data_storage,
+            data_keys=["payloads"],
+            pre_start=self._start_receiver,
+            post_stop=self._stop_receiver,
+        )
+
+    def _start_receiver(self, service):
+        http_server_run(service.test_suite_http_port)
+        self.service.wait_for_http_endpoint(
+            f"http://127.0.0.1:{service.test_suite_http_port}/ping",
+            timeout=10,
+            interval=0.5,
+        )
+
+    def _stop_receiver(self, service):
+        try:
+            requests.post(f"http://127.0.0.1:{service.test_suite_http_port}/shutdown", timeout=2)
+        except requests.RequestException:
+            pass
+
+    def start(self):
+        self.service.start()
+        self.flb_listener_port = self.service.flb_listener_port
+
+    def stop(self):
+        self.service.stop()
+
+    def assert_running(self):
+        assert self.service.flb.process is not None
+        assert self.service.flb.process.poll() is None
+
+    def read_forwarded_payloads(self, timeout=10):
+        return self.service.wait_for_condition(
+            lambda: data_storage["payloads"] if data_storage["payloads"] else None,
+            timeout=timeout,
+            interval=0.2,
+            description="forwarded mqtt payloads",
+        )
+
+
+def _recv_connack(sock):
+    response = sock.recv(4)
+    assert response
+    assert response[0] == 0x20
+
+
+def _build_publish_packet(payload, topic=b"a/b"):
+    remaining_length = 2 + len(topic) + len(payload)
+    return bytes([0x30, remaining_length]) + len(topic).to_bytes(2, "big") + topic + payload
+
+
+def _assert_record(payloads):
+    assert len(payloads) == 1
+    assert isinstance(payloads[0], list)
+    assert len(payloads[0]) == 1
+    record = payloads[0][0]
+    assert record["topic"] == "a/b"
+    assert record["key"] == "val"
+
+
+def _assert_payload_key_record(payloads):
+    assert len(payloads) == 1
+    assert isinstance(payloads[0], list)
+    assert len(payloads[0]) == 1
+    record = payloads[0][0]
+    assert record["topic"] == "a/b"
+    assert record["payload_k"]["key"] == "val"
+
+
+def test_in_mqtt_publish_forwards_json():
+    service = Service()
+    service.start()
+
+    try:
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as sock:
+            sock.sendall(MQTT_CONNECT_PACKET)
+            _recv_connack(sock)
+            sock.sendall(_build_publish_packet(MQTT_VALID_PAYLOAD))
+
+        payloads = service.read_forwarded_payloads()
+    finally:
+        service.stop()
+
+    _assert_record(payloads)
+
+
+def test_in_mqtt_truncated_publish_recovers():
+    service = Service()
+    service.start()
+
+    try:
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as sock:
+            sock.sendall(MQTT_CONNECT_PACKET)
+            _recv_connack(sock)
+            sock.sendall(MQTT_TRUNCATED_QOS1_PUBLISH_PACKET)
+
+        time.sleep(0.2)
+        assert data_storage["payloads"] == []
+        service.assert_running()
+
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as recovery_sock:
+            recovery_sock.sendall(MQTT_CONNECT_PACKET)
+            _recv_connack(recovery_sock)
+            recovery_sock.sendall(_build_publish_packet(MQTT_VALID_PAYLOAD))
+
+        payloads = service.read_forwarded_payloads()
+    finally:
+        service.stop()
+
+    _assert_record(payloads)
+
+
+def test_in_mqtt_empty_publish_recovers():
+    service = Service()
+    service.start()
+
+    try:
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as sock:
+            sock.sendall(MQTT_CONNECT_PACKET)
+            _recv_connack(sock)
+            sock.sendall(MQTT_EMPTY_PUBLISH_PACKET)
+
+            time.sleep(0.2)
+            assert data_storage["payloads"] == []
+            service.assert_running()
+
+            sock.sendall(_build_publish_packet(MQTT_VALID_PAYLOAD))
+
+        payloads = service.read_forwarded_payloads()
+    finally:
+        service.stop()
+
+    _assert_record(payloads)
+
+
+def test_in_mqtt_invalid_topic_length_recovers():
+    service = Service()
+    service.start()
+
+    try:
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as sock:
+            sock.sendall(MQTT_CONNECT_PACKET)
+            _recv_connack(sock)
+            sock.sendall(MQTT_INVALID_TOPIC_LENGTH_PACKET)
+
+        time.sleep(0.2)
+        assert data_storage["payloads"] == []
+        service.assert_running()
+
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as recovery_sock:
+            recovery_sock.sendall(MQTT_CONNECT_PACKET)
+            _recv_connack(recovery_sock)
+            recovery_sock.sendall(_build_publish_packet(MQTT_VALID_PAYLOAD))
+
+        payloads = service.read_forwarded_payloads()
+    finally:
+        service.stop()
+
+    _assert_record(payloads)
+
+
+def test_in_mqtt_invalid_json_payload_recovers():
+    service = Service()
+    service.start()
+
+    try:
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as sock:
+            sock.sendall(MQTT_CONNECT_PACKET)
+            _recv_connack(sock)
+            sock.sendall(_build_publish_packet(MQTT_INVALID_JSON_PAYLOAD))
+
+        time.sleep(0.2)
+        assert data_storage["payloads"] == []
+        service.assert_running()
+
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as recovery_sock:
+            recovery_sock.sendall(MQTT_CONNECT_PACKET)
+            _recv_connack(recovery_sock)
+            recovery_sock.sendall(_build_publish_packet(MQTT_VALID_PAYLOAD))
+
+        payloads = service.read_forwarded_payloads()
+    finally:
+        service.stop()
+
+    _assert_record(payloads)
+
+
+def test_in_mqtt_payload_key_wraps_payload():
+    service = Service("in_mqtt_payload_key.yaml")
+    service.start()
+
+    try:
+        with socket.create_connection(("127.0.0.1", service.flb_listener_port), timeout=5) as sock:
+            sock.sendall(MQTT_CONNECT_PACKET)
+            _recv_connack(sock)
+            sock.sendall(_build_publish_packet(MQTT_VALID_PAYLOAD))
+
+        payloads = service.read_forwarded_payloads()
+    finally:
+        service.stop()
+
+    _assert_payload_key_record(payloads)

--- a/scenarios/in_opentelemetry/config/003-stdout-otlp-json.yaml
+++ b/scenarios/in_opentelemetry/config/003-stdout-otlp-json.yaml
@@ -1,0 +1,15 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: stdout
+      match: '*'
+      format: otlp_json

--- a/scenarios/in_opentelemetry/config/004-stdout-otlp-json-pretty.yaml
+++ b/scenarios/in_opentelemetry/config/004-stdout-otlp-json-pretty.yaml
@@ -1,0 +1,15 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: stdout
+      match: '*'
+      format: otlp_json_pretty

--- a/scenarios/in_opentelemetry/config/otlp_http1_cleartext_oauth2.yaml
+++ b/scenarios/in_opentelemetry/config/otlp_http1_cleartext_oauth2.yaml
@@ -1,0 +1,54 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: off
+      tls: off
+      oauth2.validate: true
+      oauth2.issuer: issuer
+      oauth2.jwks_url: http://127.0.0.1:${TEST_SUITE_JWKS_PORT}/jwks
+      oauth2.allowed_audience: audience
+      oauth2.allowed_clients: client1
+      processors:
+        logs:
+          - name: content_modifier
+            context: otel_resource_attributes
+            action: upsert
+            key: "aaa"
+            value: "bbb"
+
+          - name: content_modifier
+            context: otel_resource_attributes
+            action: delete
+            key: "service.name"
+
+          - name: content_modifier
+            context: otel_scope_attributes
+            action: upsert
+            key: "mynewscope"
+            value: "123"
+
+          - name: content_modifier
+            context: otel_scope_name
+            action: upsert
+            value: "new scope name"
+
+          - name: content_modifier
+            context: otel_scope_version
+            action: upsert
+            value: "3.1.0"
+
+  outputs:
+    - name: stdout
+      match: '*'
+
+    - name: opentelemetry
+      match: '*'
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}

--- a/scenarios/in_opentelemetry/config/otlp_http1_tls_oauth2.yaml
+++ b/scenarios/in_opentelemetry/config/otlp_http1_tls_oauth2.yaml
@@ -1,0 +1,57 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: off
+      tls: on
+      tls.verify: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+      oauth2.validate: true
+      oauth2.issuer: issuer
+      oauth2.jwks_url: http://127.0.0.1:${TEST_SUITE_JWKS_PORT}/jwks
+      oauth2.allowed_audience: audience
+      oauth2.allowed_clients: client1
+      processors:
+        logs:
+          - name: content_modifier
+            context: otel_resource_attributes
+            action: upsert
+            key: "aaa"
+            value: "bbb"
+
+          - name: content_modifier
+            context: otel_resource_attributes
+            action: delete
+            key: "service.name"
+
+          - name: content_modifier
+            context: otel_scope_attributes
+            action: upsert
+            key: "mynewscope"
+            value: "123"
+
+          - name: content_modifier
+            context: otel_scope_name
+            action: upsert
+            value: "new scope name"
+
+          - name: content_modifier
+            context: otel_scope_version
+            action: upsert
+            value: "3.1.0"
+
+  outputs:
+    - name: stdout
+      match: '*'
+
+    - name: opentelemetry
+      match: '*'
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}

--- a/scenarios/in_opentelemetry/config/otlp_http2_cleartext_oauth2.yaml
+++ b/scenarios/in_opentelemetry/config/otlp_http2_cleartext_oauth2.yaml
@@ -1,0 +1,54 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: on
+      tls: off
+      oauth2.validate: true
+      oauth2.issuer: issuer
+      oauth2.jwks_url: http://127.0.0.1:${TEST_SUITE_JWKS_PORT}/jwks
+      oauth2.allowed_audience: audience
+      oauth2.allowed_clients: client1
+      processors:
+        logs:
+          - name: content_modifier
+            context: otel_resource_attributes
+            action: upsert
+            key: "aaa"
+            value: "bbb"
+
+          - name: content_modifier
+            context: otel_resource_attributes
+            action: delete
+            key: "service.name"
+
+          - name: content_modifier
+            context: otel_scope_attributes
+            action: upsert
+            key: "mynewscope"
+            value: "123"
+
+          - name: content_modifier
+            context: otel_scope_name
+            action: upsert
+            value: "new scope name"
+
+          - name: content_modifier
+            context: otel_scope_version
+            action: upsert
+            value: "3.1.0"
+
+  outputs:
+    - name: stdout
+      match: '*'
+
+    - name: opentelemetry
+      match: '*'
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}

--- a/scenarios/in_opentelemetry/config/otlp_http2_tls_oauth2.yaml
+++ b/scenarios/in_opentelemetry/config/otlp_http2_tls_oauth2.yaml
@@ -1,0 +1,57 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      http2: on
+      tls: on
+      tls.verify: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+      oauth2.validate: true
+      oauth2.issuer: issuer
+      oauth2.jwks_url: http://127.0.0.1:${TEST_SUITE_JWKS_PORT}/jwks
+      oauth2.allowed_audience: audience
+      oauth2.allowed_clients: client1
+      processors:
+        logs:
+          - name: content_modifier
+            context: otel_resource_attributes
+            action: upsert
+            key: "aaa"
+            value: "bbb"
+
+          - name: content_modifier
+            context: otel_resource_attributes
+            action: delete
+            key: "service.name"
+
+          - name: content_modifier
+            context: otel_scope_attributes
+            action: upsert
+            key: "mynewscope"
+            value: "123"
+
+          - name: content_modifier
+            context: otel_scope_name
+            action: upsert
+            value: "new scope name"
+
+          - name: content_modifier
+            context: otel_scope_version
+            action: upsert
+            value: "3.1.0"
+
+  outputs:
+    - name: stdout
+      match: '*'
+
+    - name: opentelemetry
+      match: '*'
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}

--- a/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
+++ b/scenarios/in_opentelemetry/tests/test_in_opentelemetry_001.py
@@ -20,13 +20,17 @@ import logging
 import time
 import base64
 from concurrent.futures import ThreadPoolExecutor
+import grpc
 import requests
 import pytest
 
 # OTel imports to convert from JSON to OTLP Protobuf
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceResponse
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceResponse
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceResponse
 from google.protobuf import json_format
 
 # local imports
@@ -34,9 +38,15 @@ from utils.data_utils import read_json_file
 from utils.http_matrix import PROTOCOL_CASES, run_curl_request
 from utils.test_service import FluentBitTestService
 
+from server.http_server import http_server_run
 from server.otlp_server import configure_otlp_response, otlp_server_run, data_storage
 
 logger = logging.getLogger(__name__)
+MOCK_VALID_JWT = (
+    "eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3QiLCJ0eXAiOiJKV1QifQ."
+    "eyJleHAiOjE4OTM0NTYwMDAsImlzcyI6Imlzc3VlciIsImF1ZCI6ImF1ZGllbmNlIiwiYXpwIjoiY2xpZW50MSJ9."
+    "TqWs06LUpQa0FGLejnOkWAD6v562d5CUh2NwsJ7iAuae9-WNFBKU6mP1zAaoafla6o5npee7RfbSzZNFI4PKhqAj69789JjAYV7IW-GSuMwJejHdVOWmCc5lmcZPH0EVxEkHA6lFQxYQwDCrfQ8Sd4Q3vYCV6sLPENcuNpQi9ytjVjaZs_7ONH2oA-sZ7EUchqJJoIBPfjit2yYsq9NeemxCzYMtngiC-IX12eEfaQ1cVYPIjhhN_NaMvapznp-BW4gnXkNoAZ1S-p1axWWY-6UgRdMYOr0Hy5PHQ9fCuHJ6Z-blYdtuGavCUGHK5ghX-JdH1WJ51F89992dQ5yF_w"
+)
 
 IN_OPENTELEMETRY_PROTOCOL_CONFIGS = {
     "http1_cleartext": "otlp_http1_cleartext.yaml",
@@ -51,6 +61,26 @@ IN_OPENTELEMETRY_WORKER_PROTOCOL_CONFIGS = {
     "http1_tls": "otlp_http1_tls_workers.yaml",
     "http2_tls": "otlp_http2_tls_workers.yaml",
 }
+
+IN_OPENTELEMETRY_OAUTH2_PROTOCOL_CONFIGS = {
+    "http1_cleartext": "otlp_http1_cleartext_oauth2.yaml",
+    "http2_cleartext": "otlp_http2_cleartext_oauth2.yaml",
+    "http1_tls": "otlp_http1_tls_oauth2.yaml",
+    "http2_tls": "otlp_http2_tls_oauth2.yaml",
+}
+
+IN_OPENTELEMETRY_GRPC_OAUTH2_CASES = [
+    {
+        "id": "grpc_cleartext",
+        "config_file": "otlp_http2_cleartext_oauth2.yaml",
+        "use_tls": False,
+    },
+    {
+        "id": "grpc_tls",
+        "config_file": "otlp_http2_tls_oauth2.yaml",
+        "use_tls": True,
+    },
+]
 
 #  [Fluent Bit Test Suite]
 #    - Start Fluent Bit:
@@ -133,14 +163,78 @@ def iter_spans(output):
                     "span_attributes": span_attributes,
                 }
 
+
+def read_stdout_otlp_json(service, root_key, timeout=10, interval=0.25):
+    deadline = time.time() + timeout
+    decoder = json.JSONDecoder()
+
+    while time.time() < deadline:
+        if service.flb and service.flb.log_file and os.path.exists(service.flb.log_file):
+            with open(service.flb.log_file, "r", encoding="utf-8", errors="replace") as log_file:
+                content = log_file.read()
+
+            matches = []
+
+            for offset, character in enumerate(content):
+                if character != "{":
+                    continue
+
+                try:
+                    payload, _ = decoder.raw_decode(content[offset:])
+                except json.JSONDecodeError:
+                    continue
+
+                if isinstance(payload, dict) and root_key in payload:
+                    matches.append(payload)
+
+            if matches:
+                return matches[-1]
+
+        time.sleep(interval)
+
+    raise TimeoutError(f"Timed out waiting for stdout OTLP JSON payload with root key {root_key}")
+
+
+def read_stdout_otlp_json_text(service, root_key, timeout=10, interval=0.25):
+    deadline = time.time() + timeout
+    decoder = json.JSONDecoder()
+
+    while time.time() < deadline:
+        if service.flb and service.flb.log_file and os.path.exists(service.flb.log_file):
+            with open(service.flb.log_file, "r", encoding="utf-8", errors="replace") as log_file:
+                content = log_file.read()
+
+            matches = []
+
+            for offset, character in enumerate(content):
+                if character != "{":
+                    continue
+
+                try:
+                    payload, end = decoder.raw_decode(content[offset:])
+                except json.JSONDecodeError:
+                    continue
+
+                if isinstance(payload, dict) and root_key in payload:
+                    matches.append(content[offset:offset + end])
+
+            if matches:
+                return matches[-1]
+
+        time.sleep(interval)
+
+    raise TimeoutError(f"Timed out waiting for stdout OTLP JSON payload with root key {root_key}")
+
 class Service:
-    def __init__(self, config_file):
+    def __init__(self, config_file, *, use_auth_server=False):
         # Compose the absolute path for the Fluent Bit configuration file
         self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '../config/', config_file))
         test_path = os.path.dirname(os.path.abspath(__file__))
         cert_dir = os.path.abspath(os.path.join(test_path, "../../in_splunk/certificate"))
         self.tls_crt_file = os.path.join(cert_dir, "certificate.pem")
         self.tls_key_file = os.path.join(cert_dir, "private_key.pem")
+        self.use_auth_server = use_auth_server
+        self.auth_server_port = None
         self.service = FluentBitTestService(
             self.config_file,
             data_storage=data_storage,
@@ -154,11 +248,24 @@ class Service:
         )
 
     def _start_receiver(self, service):
+        if self.use_auth_server:
+            self.auth_server_port = service.allocate_port_env("TEST_SUITE_JWKS_PORT")
+            http_server_run(self.auth_server_port)
+            self.service.wait_for_http_endpoint(
+                f"http://127.0.0.1:{self.auth_server_port}/ping",
+                timeout=10,
+                interval=0.5,
+            )
         otlp_server_run(service.test_suite_http_port)
         url = f'http://127.0.0.1:{service.test_suite_http_port}/ping'
         self.service.wait_for_http_endpoint(url, timeout=10, interval=0.5)
 
     def _stop_receiver(self, service):
+        if self.auth_server_port is not None:
+            try:
+                requests.post(f"http://127.0.0.1:{self.auth_server_port}/shutdown", timeout=2)
+            except requests.RequestException:
+                pass
         try:
             requests.post(f'http://localhost:{service.test_suite_http_port}/shutdown', timeout=2)
         except requests.RequestException:
@@ -227,6 +334,49 @@ class Service:
         self.send_request(endpoint, protobuf_payload)
 
         return self.read_response(signal_type)
+
+    def send_grpc_request(self, signal_type, payload, *, authorization=None, use_tls=False):
+        method_map = {
+            "logs": (
+                "/opentelemetry.proto.collector.logs.v1.LogsService/Export",
+                ExportLogsServiceRequest.SerializeToString,
+                ExportLogsServiceResponse.FromString,
+            ),
+            "metrics": (
+                "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export",
+                ExportMetricsServiceRequest.SerializeToString,
+                ExportMetricsServiceResponse.FromString,
+            ),
+            "traces": (
+                "/opentelemetry.proto.collector.trace.v1.TraceService/Export",
+                ExportTraceServiceRequest.SerializeToString,
+                ExportTraceServiceResponse.FromString,
+            ),
+        }
+        method_path, serializer, deserializer = method_map[signal_type]
+        target = f"127.0.0.1:{self.flb_listener_port}"
+
+        if use_tls:
+            with open(self.tls_crt_file, "rb") as certificate_file:
+                channel_credentials = grpc.ssl_channel_credentials(certificate_file.read())
+            channel = grpc.secure_channel(target, channel_credentials)
+        else:
+            channel = grpc.insecure_channel(target)
+
+        metadata = []
+        if authorization is not None:
+            metadata.append(("authorization", authorization))
+
+        try:
+            grpc.channel_ready_future(channel).result(timeout=5)
+            rpc = channel.unary_unary(
+                method_path,
+                request_serializer=serializer,
+                response_deserializer=deserializer,
+            )
+            return rpc(payload, metadata=metadata, timeout=5)
+        finally:
+            channel.close()
 
     def build_otel_payload(self, json_input, signal_type):
         base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../tests', 'data_files'))
@@ -432,6 +582,226 @@ def test_in_opentelemetry_rejects_invalid_traces_payload():
 
     assert response.status_code >= 400
     assert len(data_storage["traces"]) == 0
+
+
+def test_in_opentelemetry_stdout_otlp_json_logs():
+    service = Service("003-stdout-otlp-json.yaml")
+    service.start()
+
+    payload = service.build_otel_payload("test_logs_001.in.json", "logs")
+    response = service.send_raw_request("/v1/logs", payload)
+    assert 200 <= response.status_code < 300
+
+    output = read_stdout_otlp_json(service, "resourceLogs")
+    service.stop()
+
+    records = list(iter_log_records(output))
+    assert len(records) >= 2
+    assert records[0]["record"]["severityText"] == "INFO"
+    assert records[0]["record"]["timeUnixNano"] == "1650917400000000000"
+    assert records[0]["resource_attributes"]["service.name"] == "example-service"
+
+
+def test_in_opentelemetry_stdout_otlp_json_metrics():
+    service = Service("003-stdout-otlp-json.yaml")
+    service.start()
+
+    payload = service.build_otel_payload("test_metrics_001.in.json", "metrics")
+    response = service.send_raw_request("/v1/metrics", payload)
+    assert 200 <= response.status_code < 300
+
+    output = read_stdout_otlp_json(service, "resourceMetrics")
+    service.stop()
+
+    metric_entry = list(iter_metric_entries(output))[0]
+    metric = metric_entry["metric"]
+
+    assert metric["name"] == "requests_total"
+    assert metric["sum"]["dataPoints"][0]["asInt"] == "42"
+    assert metric_entry["resource_attributes"]["service.instance.id"] == "instance-1"
+    assert metric["sum"]["dataPoints"][0]["attributes"][0]["key"] == "service.name"
+    assert metric["sum"]["dataPoints"][0]["attributes"][0]["value"]["stringValue"] == "checkout"
+
+
+def test_in_opentelemetry_stdout_otlp_json_traces():
+    service = Service("003-stdout-otlp-json.yaml")
+    service.start()
+
+    payload = service.build_otel_payload("test_traces_001.in.json", "traces")
+    response = service.send_raw_request("/v1/traces", payload)
+    assert 200 <= response.status_code < 300
+
+    output = read_stdout_otlp_json(service, "resourceSpans")
+    service.stop()
+
+    span_entry = list(iter_spans(output))[0]
+    span = span_entry["span"]
+
+    assert span["name"] == "checkout-span"
+    assert span["traceId"] == "e5bf1e7df7fbf7cd37f35d37776ebd6fadf7f35ddf73ad1c"
+    assert span["spanId"] == "79e7b5f5bede7377356f5ef8"
+    assert span_entry["resource_attributes"]["service.name"] == "checkout"
+
+
+def test_in_opentelemetry_stdout_otlp_json_pretty_logs():
+    service = Service("004-stdout-otlp-json-pretty.yaml")
+    service.start()
+
+    payload = service.build_otel_payload("test_logs_001.in.json", "logs")
+    response = service.send_raw_request("/v1/logs", payload)
+    assert 200 <= response.status_code < 300
+
+    output = read_stdout_otlp_json(service, "resourceLogs")
+    output_text = read_stdout_otlp_json_text(service, "resourceLogs")
+    service.stop()
+
+    records = list(iter_log_records(output))
+    assert len(records) >= 2
+    assert records[0]["record"]["severityText"] == "INFO"
+    assert "\n  \"resourceLogs\": [" in output_text
+    assert "\n          \"logRecords\": [" in output_text
+
+
+def test_in_opentelemetry_stdout_otlp_json_pretty_metrics():
+    service = Service("004-stdout-otlp-json-pretty.yaml")
+    service.start()
+
+    payload = service.build_otel_payload("test_metrics_001.in.json", "metrics")
+    response = service.send_raw_request("/v1/metrics", payload)
+    assert 200 <= response.status_code < 300
+
+    output = read_stdout_otlp_json(service, "resourceMetrics")
+    output_text = read_stdout_otlp_json_text(service, "resourceMetrics")
+    service.stop()
+
+    metric_entry = list(iter_metric_entries(output))[0]
+    assert metric_entry["metric"]["name"] == "requests_total"
+    assert "\n  \"resourceMetrics\": [" in output_text
+    assert "\n          \"metrics\": [" in output_text
+
+
+def test_in_opentelemetry_stdout_otlp_json_pretty_traces():
+    service = Service("004-stdout-otlp-json-pretty.yaml")
+    service.start()
+
+    payload = service.build_otel_payload("test_traces_001.in.json", "traces")
+    response = service.send_raw_request("/v1/traces", payload)
+    assert 200 <= response.status_code < 300
+
+    output = read_stdout_otlp_json(service, "resourceSpans")
+    output_text = read_stdout_otlp_json_text(service, "resourceSpans")
+    service.stop()
+
+    span_entry = list(iter_spans(output))[0]
+    assert span_entry["span"]["name"] == "checkout-span"
+    assert "\n  \"resourceSpans\": [" in output_text
+    assert "\n          \"spans\": [" in output_text
+
+
+@pytest.mark.parametrize("case", PROTOCOL_CASES, ids=[case["id"] for case in PROTOCOL_CASES])
+def test_in_opentelemetry_oauth2_requires_bearer_token(case):
+    service = Service(
+        IN_OPENTELEMETRY_OAUTH2_PROTOCOL_CONFIGS[case["config_key"]],
+        use_auth_server=True,
+    )
+    service.start()
+
+    scheme = "https" if case["use_tls"] else "http"
+    payload = service.build_otel_payload("test_logs_001.in.json", "logs")
+    result = run_curl_request(
+        f"{scheme}://localhost:{service.flb_listener_port}/v1/logs",
+        payload,
+        headers=["Content-Type: application/x-protobuf"],
+        http_mode=case["http_mode"],
+        ca_cert_path=service.tls_crt_file if case["use_tls"] else None,
+    )
+
+    service.stop()
+
+    assert result["status_code"] == 401
+    assert len(data_storage["logs"]) == 0
+
+
+@pytest.mark.parametrize("case", PROTOCOL_CASES, ids=[case["id"] for case in PROTOCOL_CASES])
+def test_in_opentelemetry_oauth2_accepts_valid_jwt(case):
+    service = Service(
+        IN_OPENTELEMETRY_OAUTH2_PROTOCOL_CONFIGS[case["config_key"]],
+        use_auth_server=True,
+    )
+    service.start()
+
+    scheme = "https" if case["use_tls"] else "http"
+    payload = service.build_otel_payload("test_logs_001.in.json", "logs")
+    result = run_curl_request(
+        f"{scheme}://localhost:{service.flb_listener_port}/v1/logs",
+        payload,
+        headers=[
+            "Content-Type: application/x-protobuf",
+            f"Authorization: Bearer {MOCK_VALID_JWT}",
+        ],
+        http_mode=case["http_mode"],
+        ca_cert_path=service.tls_crt_file if case["use_tls"] else None,
+    )
+    response_payload = service.read_response("logs")
+
+    service.stop()
+
+    assert result["status_code"] == 201
+    assert result["http_version"] == case["expected_http_version"]
+    assert len(response_payload["resourceLogs"]) > 0
+
+
+@pytest.mark.parametrize("case", IN_OPENTELEMETRY_GRPC_OAUTH2_CASES, ids=[case["id"] for case in IN_OPENTELEMETRY_GRPC_OAUTH2_CASES])
+def test_in_opentelemetry_grpc_oauth2_requires_bearer_token(case):
+    service = Service(case["config_file"], use_auth_server=True)
+    service.start()
+
+    payload = json_format.Parse(
+        json.dumps(
+            read_json_file(
+                os.path.abspath(
+                    os.path.join(os.path.dirname(__file__), "../tests/data_files/test_logs_001.in.json")
+                )
+            )
+        ),
+        ExportLogsServiceRequest(),
+    )
+
+    with pytest.raises(grpc.RpcError) as exc_info:
+        service.send_grpc_request("logs", payload, use_tls=case["use_tls"])
+
+    service.stop()
+
+    assert exc_info.value.code() == grpc.StatusCode.UNAUTHENTICATED
+    assert len(data_storage["logs"]) == 0
+
+
+@pytest.mark.parametrize("case", IN_OPENTELEMETRY_GRPC_OAUTH2_CASES, ids=[case["id"] for case in IN_OPENTELEMETRY_GRPC_OAUTH2_CASES])
+def test_in_opentelemetry_grpc_oauth2_accepts_valid_jwt(case):
+    service = Service(case["config_file"], use_auth_server=True)
+    service.start()
+
+    payload = json_format.Parse(
+        json.dumps(
+            read_json_file(
+                os.path.abspath(
+                    os.path.join(os.path.dirname(__file__), "../tests/data_files/test_logs_001.in.json")
+                )
+            )
+        ),
+        ExportLogsServiceRequest(),
+    )
+    service.send_grpc_request(
+        "logs",
+        payload,
+        authorization=f"Bearer {MOCK_VALID_JWT}",
+        use_tls=case["use_tls"],
+    )
+    response_payload = service.read_response("logs")
+
+    service.stop()
+
+    assert len(response_payload["resourceLogs"]) > 0
 
 
 def test_out_opentelemetry_receiver_error_is_observable():

--- a/scenarios/in_prometheus_remote_write/config/receiver_http1_cleartext_workers.yaml
+++ b/scenarios/in_prometheus_remote_write/config/receiver_http1_cleartext_workers.yaml
@@ -1,0 +1,20 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: prometheus_remote_write
+      listen: 127.0.0.1
+      port: ${PROM_RW_RECEIVER_PORT}
+      uri: /write
+      http2: off
+      successful_response_code: 201
+      http_server.workers: 4
+
+  outputs:
+    - name: stdout
+      match: "*"

--- a/scenarios/in_prometheus_remote_write/config/receiver_http1_tls_workers.yaml
+++ b/scenarios/in_prometheus_remote_write/config/receiver_http1_tls_workers.yaml
@@ -1,0 +1,25 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: prometheus_remote_write
+      listen: 127.0.0.1
+      port: ${PROM_RW_RECEIVER_PORT}
+      uri: /write
+      http2: off
+      successful_response_code: 201
+      tls: on
+      tls.verify: no
+      tls.vhost: localhost
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+      http_server.workers: 4
+
+  outputs:
+    - name: stdout
+      match: "*"

--- a/scenarios/in_prometheus_remote_write/config/receiver_http2_cleartext_workers.yaml
+++ b/scenarios/in_prometheus_remote_write/config/receiver_http2_cleartext_workers.yaml
@@ -1,0 +1,20 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: prometheus_remote_write
+      listen: 127.0.0.1
+      port: ${PROM_RW_RECEIVER_PORT}
+      uri: /write
+      http2: on
+      successful_response_code: 201
+      http_server.workers: 4
+
+  outputs:
+    - name: stdout
+      match: "*"

--- a/scenarios/in_prometheus_remote_write/config/receiver_http2_tls_workers.yaml
+++ b/scenarios/in_prometheus_remote_write/config/receiver_http2_tls_workers.yaml
@@ -1,0 +1,25 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: prometheus_remote_write
+      listen: 127.0.0.1
+      port: ${PROM_RW_RECEIVER_PORT}
+      uri: /write
+      http2: on
+      successful_response_code: 201
+      tls: on
+      tls.verify: no
+      tls.vhost: localhost
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+      http_server.workers: 4
+
+  outputs:
+    - name: stdout
+      match: "*"

--- a/scenarios/in_prometheus_remote_write/tests/test_in_prometheus_remote_write_001.py
+++ b/scenarios/in_prometheus_remote_write/tests/test_in_prometheus_remote_write_001.py
@@ -10,22 +10,34 @@ from utils.network import find_available_port
 PROM_RW_CASES = [
     {
         "id": "http1_cleartext",
-        "receiver_config": "receiver_http1_cleartext.yaml",
+        "receiver_config": {
+            False: "receiver_http1_cleartext.yaml",
+            True: "receiver_http1_cleartext_workers.yaml",
+        },
         "sender_config": "sender_cleartext.yaml",
     },
     {
         "id": "http2_cleartext",
-        "receiver_config": "receiver_http2_cleartext.yaml",
+        "receiver_config": {
+            False: "receiver_http2_cleartext.yaml",
+            True: "receiver_http2_cleartext_workers.yaml",
+        },
         "sender_config": "sender_cleartext.yaml",
     },
     {
         "id": "http1_tls",
-        "receiver_config": "receiver_http1_tls.yaml",
+        "receiver_config": {
+            False: "receiver_http1_tls.yaml",
+            True: "receiver_http1_tls_workers.yaml",
+        },
         "sender_config": "sender_tls.yaml",
     },
     {
         "id": "http2_tls",
-        "receiver_config": "receiver_http2_tls.yaml",
+        "receiver_config": {
+            False: "receiver_http2_tls.yaml",
+            True: "receiver_http2_tls_workers.yaml",
+        },
         "sender_config": "sender_tls.yaml",
     },
 ]
@@ -92,12 +104,20 @@ class Service:
         raise TimeoutError(f"Timed out waiting for {pattern} in {path}")
 
 
+@pytest.mark.parametrize("workers_enabled", [False, True], ids=["single_listener", "workers_4"])
 @pytest.mark.parametrize("case", PROM_RW_CASES, ids=[case["id"] for case in PROM_RW_CASES])
-def test_in_prometheus_remote_write_matrix(case):
-    service = Service(case["receiver_config"], case["sender_config"])
+def test_in_prometheus_remote_write_matrix(case, workers_enabled):
+    service = Service(case["receiver_config"][workers_enabled], case["sender_config"])
     service.start()
 
     try:
+        if workers_enabled:
+            service.wait_for_log(
+                service.receiver.log_file,
+                "with 4 workers",
+                timeout=20,
+                interval=0.5,
+            )
         receiver_log = service.wait_for_log(
             service.receiver.log_file,
             "fluentbit_input_metrics_scrapes_total",

--- a/scenarios/in_splunk/config/splunk_http1_keepalive_workers.yaml
+++ b/scenarios/in_splunk/config/splunk_http1_keepalive_workers.yaml
@@ -1,0 +1,17 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+pipeline:
+  inputs:
+    - name: splunk
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      host: 0.0.0.0
+      http2: off
+      net.keepalive: on
+      tls: off
+      http_server.workers: 4
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/in_splunk/config/splunk_http1_tls_keepalive_workers.yaml
+++ b/scenarios/in_splunk/config/splunk_http1_tls_keepalive_workers.yaml
@@ -1,0 +1,19 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+pipeline:
+  inputs:
+    - name: splunk
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      host: 0.0.0.0
+      http2: off
+      net.keepalive: on
+      tls: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+      http_server.workers: 4
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/in_splunk/config/splunk_on_http2_keepalive_workers.yaml
+++ b/scenarios/in_splunk/config/splunk_on_http2_keepalive_workers.yaml
@@ -1,0 +1,17 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+pipeline:
+  inputs:
+    - name: splunk
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      host: 0.0.0.0
+      http2: on
+      net.keepalive: on
+      tls: off
+      http_server.workers: 4
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/in_splunk/config/splunk_on_http2_on_keepalive_on_tls_on_workers.yaml
+++ b/scenarios/in_splunk/config/splunk_on_http2_on_keepalive_on_tls_on_workers.yaml
@@ -1,0 +1,19 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+pipeline:
+  inputs:
+    - name: splunk
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+      host: 0.0.0.0
+      http2: on
+      net.keepalive: on
+      tls: on
+      tls.crt_file: ${CERTIFICATE_TEST}
+      tls.key_file: ${PRIVATE_KEY_TEST}
+      http_server.workers: 4
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/in_splunk/tests/test_in_splunk_001.py
+++ b/scenarios/in_splunk/tests/test_in_splunk_001.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 
 import pytest
 import requests
@@ -30,6 +31,16 @@ class Service:
         self.service.start()
         self.flb = self.service.flb
         self.flb_listener_port = self.service.flb_listener_port
+
+    def wait_for_log_message(self, pattern, timeout=10, interval=0.25):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.flb and self.flb.log_file and os.path.exists(self.flb.log_file):
+                with open(self.flb.log_file, "r", encoding="utf-8", errors="replace") as log_file:
+                    if pattern in log_file.read():
+                        return True
+            time.sleep(interval)
+        raise TimeoutError(f"Timed out waiting for log pattern: {pattern}")
 
     def stop(self):
         self.service.stop()
@@ -88,17 +99,28 @@ def create_splunk_headers(content_type="application/json"):
 
 
 SPLUNK_PROTOCOL_CONFIGS = {
-    "http1_cleartext": "splunk_http1_keepalive.yaml",
-    "http2_cleartext": "splunk_on_http2_keepalive.yaml",
-    "http1_tls": "splunk_http1_tls_keepalive.yaml",
-    "http2_tls": "splunk_on_http2_on_keepalive_on_tls_on.yaml",
+    False: {
+        "http1_cleartext": "splunk_http1_keepalive.yaml",
+        "http2_cleartext": "splunk_on_http2_keepalive.yaml",
+        "http1_tls": "splunk_http1_tls_keepalive.yaml",
+        "http2_tls": "splunk_on_http2_on_keepalive_on_tls_on.yaml",
+    },
+    True: {
+        "http1_cleartext": "splunk_http1_keepalive_workers.yaml",
+        "http2_cleartext": "splunk_on_http2_keepalive_workers.yaml",
+        "http1_tls": "splunk_http1_tls_keepalive_workers.yaml",
+        "http2_tls": "splunk_on_http2_on_keepalive_on_tls_on_workers.yaml",
+    },
 }
 
 
+@pytest.mark.parametrize("workers_enabled", [False, True], ids=["single_listener", "workers_4"])
 @pytest.mark.parametrize("case", PROTOCOL_CASES, ids=[case["id"] for case in PROTOCOL_CASES])
-def test_splunk_protocol_matrix(case):
-    service = Service(SPLUNK_PROTOCOL_CONFIGS[case["config_key"]])
+def test_splunk_protocol_matrix(case, workers_enabled):
+    service = Service(SPLUNK_PROTOCOL_CONFIGS[workers_enabled][case["config_key"]])
     service.start()
+    if workers_enabled:
+        service.wait_for_log_message("with 4 workers", timeout=10)
 
     scheme = "https" if case["use_tls"] else "http"
     url = f"{scheme}://localhost:{service.flb_listener_port}/services/collector"

--- a/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_oauth2.yaml
+++ b/scenarios/out_azure_logs_ingestion/config/out_azure_logs_ingestion_oauth2.yaml
@@ -1,0 +1,28 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: azure_logs_ingestion
+      dummy: '{"message":"hello from azure logs ingestion","source":"dummy","level":"info"}'
+      samples: 1
+
+  outputs:
+    - name: azure_logs_ingestion
+      match: azure_logs_ingestion
+      tenant_id: suite-tenant
+      client_id: suite-client
+      client_secret: suite-secret
+      auth_url: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token
+      dce_url: https://localhost:${TEST_SUITE_HTTP_PORT}
+      dcr_id: dcr-suite
+      table_name: suite_CL
+      compress: on
+      tls.verify: on
+      tls.verify_hostname: on
+      tls.vhost: localhost
+      tls.ca_file: ${CERTIFICATE_TEST}

--- a/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
+++ b/scenarios/out_azure_logs_ingestion/tests/test_out_azure_logs_ingestion_001.py
@@ -1,0 +1,156 @@
+import logging
+import os
+
+import requests
+
+from server.http_server import (
+    configure_http_response,
+    configure_oauth_token_response,
+    data_storage,
+    http_server_run,
+)
+from utils.test_service import FluentBitTestService
+
+logger = logging.getLogger(__name__)
+
+
+class Service:
+    def __init__(self, config_file):
+        self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
+        cert_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../in_splunk/certificate"))
+        self.tls_crt_file = os.path.join(cert_dir, "certificate.pem")
+        self.tls_key_file = os.path.join(cert_dir, "private_key.pem")
+        self.oauth_server_port = None
+        self.service = FluentBitTestService(
+            self.config_file,
+            data_storage=data_storage,
+            data_keys=["payloads", "requests"],
+            extra_env={
+                "CERTIFICATE_TEST": self.tls_crt_file,
+                "PRIVATE_KEY_TEST": self.tls_key_file,
+            },
+            pre_start=self._start_receiver,
+            post_stop=self._stop_receiver,
+        )
+
+    def _start_receiver(self, service):
+        self.oauth_server_port = service.allocate_port_env("TEST_SUITE_OAUTH_PORT")
+        http_server_run(self.oauth_server_port)
+        http_server_run(
+            service.test_suite_http_port,
+            use_tls=True,
+            tls_crt_file=self.tls_crt_file,
+            tls_key_file=self.tls_key_file,
+            reset_state=False,
+        )
+
+        def _http_ready():
+            try:
+                response = requests.get(
+                    f"http://127.0.0.1:{self.oauth_server_port}/ping",
+                    timeout=1,
+                )
+                return response.status_code == 200
+            except requests.RequestException:
+                return False
+
+        def _https_ready():
+            try:
+                response = requests.get(
+                    f"https://localhost:{service.test_suite_http_port}/ping",
+                    timeout=1,
+                    verify=self.tls_crt_file,
+                )
+                return response.status_code == 200
+            except requests.RequestException:
+                return False
+
+        self.service.wait_for_condition(
+            _http_ready,
+            timeout=10,
+            interval=0.5,
+            description="azure logs ingestion oauth receiver readiness",
+        )
+
+        self.service.wait_for_condition(
+            _https_ready,
+            timeout=10,
+            interval=0.5,
+            description="azure logs ingestion receiver readiness",
+        )
+
+    def _stop_receiver(self, service):
+        try:
+            if self.oauth_server_port is not None:
+                requests.post(
+                    f"http://127.0.0.1:{self.oauth_server_port}/shutdown",
+                    timeout=2,
+                )
+        except requests.RequestException:
+            pass
+
+        try:
+            requests.post(
+                f"https://localhost:{service.test_suite_http_port}/shutdown",
+                timeout=2,
+                verify=self.tls_crt_file,
+            )
+        except requests.RequestException:
+            pass
+
+    def start(self):
+        self.service.start()
+        self.flb = self.service.flb
+        self.flb_listener_port = self.service.flb_listener_port
+        self.test_suite_http_port = self.service.test_suite_http_port
+
+    def stop(self):
+        self.service.stop()
+
+    def wait_for_requests(self, minimum_count, timeout=10):
+        return self.service.wait_for_condition(
+            lambda: data_storage["requests"] if len(data_storage["requests"]) >= minimum_count else None,
+            timeout=timeout,
+            interval=0.5,
+            description=f"{minimum_count} azure logs ingestion requests",
+        )
+
+
+def test_out_azure_logs_ingestion_legacy_oauth2_and_payload_format():
+    service = Service("out_azure_logs_ingestion_oauth2.yaml")
+    service.start()
+    configure_http_response(status_code=200, body={"status": "received"})
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    requests_seen = service.wait_for_requests(2, timeout=15)
+    service.stop()
+
+    token_request = next(request for request in requests_seen if request["path"] == "/oauth/token")
+    data_request = next(
+        request
+        for request in requests_seen
+        if request["path"] == "/dataCollectionRules/dcr-suite/streams/Custom-suite_CL"
+    )
+
+    assert token_request["method"] == "POST"
+    assert "grant_type=client_credentials" in token_request["raw_data"]
+    assert "scope=https://monitor.azure.com/.default" in token_request["raw_data"]
+    assert "client_id=suite-client" in token_request["raw_data"]
+    assert "client_secret=suite-secret" in token_request["raw_data"]
+
+    assert data_request["method"] == "POST"
+    assert data_request["query_string"] == "api-version=2021-11-01-preview"
+    assert data_request["headers"].get("Authorization") == "Bearer oauth-access-token"
+    assert data_request["headers"].get("Content-Encoding") == "gzip"
+    assert data_request["headers"].get("Content-Type") == "application/json"
+
+    payload = data_request["json"]
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    assert payload[0]["message"] == "hello from azure logs ingestion"
+    assert payload[0]["source"] == "dummy"
+    assert payload[0]["level"] == "info"
+    assert isinstance(payload[0]["@timestamp"], (int, float))

--- a/scenarios/out_kafka/config/out_kafka_basic.yaml
+++ b/scenarios/out_kafka/config/out_kafka_basic.yaml
@@ -1,0 +1,22 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_kafka
+      dummy: '{"message":"hello from out_kafka","source":"dummy"}'
+      samples: 1
+
+  outputs:
+    - name: kafka
+      match: out_kafka
+      brokers: 127.0.0.1:${TEST_SUITE_KAFKA_PORT}
+      topics: test
+      format: json
+      queue_full_retries: 1
+      rdkafka.api.version.request: false
+      rdkafka.broker.version.fallback: 0.8.2.0

--- a/scenarios/out_kafka/config/out_kafka_dynamic_topic.yaml
+++ b/scenarios/out_kafka/config/out_kafka_dynamic_topic.yaml
@@ -1,0 +1,24 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_kafka
+      dummy: '{"message":"hello dynamic topic","topic_name":"topic-dynamic","source":"dummy"}'
+      samples: 1
+
+  outputs:
+    - name: kafka
+      match: out_kafka
+      brokers: 127.0.0.1:${TEST_SUITE_KAFKA_PORT}
+      topics: test
+      dynamic_topic: true
+      topic_key: topic_name
+      format: json
+      queue_full_retries: 1
+      rdkafka.api.version.request: false
+      rdkafka.broker.version.fallback: 0.8.2.0

--- a/scenarios/out_kafka/config/out_kafka_message_key_field.yaml
+++ b/scenarios/out_kafka/config/out_kafka_message_key_field.yaml
@@ -1,0 +1,23 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_kafka
+      dummy: '{"message":"hello with key","message_key":"key-123","source":"dummy"}'
+      samples: 1
+
+  outputs:
+    - name: kafka
+      match: out_kafka
+      brokers: 127.0.0.1:${TEST_SUITE_KAFKA_PORT}
+      topics: test
+      format: json
+      message_key_field: message_key
+      queue_full_retries: 1
+      rdkafka.api.version.request: false
+      rdkafka.broker.version.fallback: 0.8.2.0

--- a/scenarios/out_kafka/config/out_kafka_msgpack.yaml
+++ b/scenarios/out_kafka/config/out_kafka_msgpack.yaml
@@ -1,0 +1,22 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_kafka
+      dummy: '{"message":"hello msgpack","count":7,"source":"dummy"}'
+      samples: 1
+
+  outputs:
+    - name: kafka
+      match: out_kafka
+      brokers: 127.0.0.1:${TEST_SUITE_KAFKA_PORT}
+      topics: test
+      format: msgpack
+      queue_full_retries: 1
+      rdkafka.api.version.request: false
+      rdkafka.broker.version.fallback: 0.8.2.0

--- a/scenarios/out_kafka/config/out_kafka_otlp_json.yaml
+++ b/scenarios/out_kafka/config/out_kafka_otlp_json.yaml
@@ -1,0 +1,24 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: kafka
+      match: "*"
+      brokers: 127.0.0.1:${TEST_SUITE_KAFKA_PORT}
+      topics: otlp-topic
+      format: otlp_json
+      message_key: static-otlp-key
+      raw_log_key: ignored_raw_key
+      message_key_field: ignored_message_key_field
+      topic_key: ignored_topic_key
+      queue_full_retries: 1
+      rdkafka.api.version.request: false
+      rdkafka.broker.version.fallback: 0.8.2.0

--- a/scenarios/out_kafka/config/out_kafka_otlp_proto.yaml
+++ b/scenarios/out_kafka/config/out_kafka_otlp_proto.yaml
@@ -1,0 +1,24 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: kafka
+      match: "*"
+      brokers: 127.0.0.1:${TEST_SUITE_KAFKA_PORT}
+      topics: otlp-topic
+      format: otlp_proto
+      message_key: static-otlp-key
+      raw_log_key: ignored_raw_key
+      message_key_field: ignored_message_key_field
+      topic_key: ignored_topic_key
+      queue_full_retries: 1
+      rdkafka.api.version.request: false
+      rdkafka.broker.version.fallback: 0.8.2.0

--- a/scenarios/out_kafka/config/out_kafka_raw.yaml
+++ b/scenarios/out_kafka/config/out_kafka_raw.yaml
@@ -1,0 +1,23 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_kafka
+      dummy: '{"key_0":"raw value","source":"dummy"}'
+      samples: 1
+
+  outputs:
+    - name: kafka
+      match: out_kafka
+      brokers: 127.0.0.1:${TEST_SUITE_KAFKA_PORT}
+      topics: test
+      format: raw
+      raw_log_key: key_0
+      queue_full_retries: 1
+      rdkafka.api.version.request: false
+      rdkafka.broker.version.fallback: 0.8.2.0

--- a/scenarios/out_kafka/tests/test_out_kafka_001.py
+++ b/scenarios/out_kafka/tests/test_out_kafka_001.py
@@ -1,0 +1,524 @@
+import json
+import os
+import struct
+from copy import deepcopy
+
+import requests
+import pytest
+from google.protobuf import json_format
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+from server.kafka_server import data_storage, kafka_server_run, kafka_server_stop
+from utils.data_utils import read_json_file
+from utils.test_service import FluentBitTestService
+
+
+class Service:
+    def __init__(self, config_file):
+        self.config_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config", config_file))
+        self.service = FluentBitTestService(
+            self.config_file,
+            data_storage=data_storage,
+            data_keys=["connections", "requests", "messages"],
+            pre_start=self._start_receiver,
+            post_stop=self._stop_receiver,
+        )
+
+    def _start_receiver(self, service):
+        self.kafka_port = service.allocate_port_env("TEST_SUITE_KAFKA_PORT")
+        kafka_server_run(self.kafka_port)
+
+    def _stop_receiver(self, service):
+        kafka_server_stop()
+
+    def start(self):
+        self.service.start()
+        self.flb = self.service.flb
+        self.flb_listener_port = self.service.flb_listener_port
+
+    def stop(self):
+        self.service.stop()
+
+    def wait_for_messages(self, minimum_count=1, timeout=10):
+        return self.service.wait_for_condition(
+            lambda: data_storage["messages"] if len(data_storage["messages"]) >= minimum_count else None,
+            timeout=timeout,
+            interval=0.5,
+            description=f"{minimum_count} Kafka messages",
+        )
+
+    def send_json_logs_payload(self, json_file):
+        payload = self._build_signal_payload(json_file, "logs")
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}/v1/logs",
+            data=payload.SerializeToString(),
+            headers={"Content-Type": "application/x-protobuf"},
+            timeout=5,
+        )
+        response.raise_for_status()
+
+    def send_json_metrics_payload(self, json_file):
+        payload = self._build_signal_payload(json_file, "metrics")
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}/v1/metrics",
+            data=payload.SerializeToString(),
+            headers={"Content-Type": "application/x-protobuf"},
+            timeout=5,
+        )
+        response.raise_for_status()
+
+    def send_json_traces_payload(self, json_file):
+        payload = self._build_signal_payload(json_file, "traces")
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}/v1/traces",
+            data=payload.SerializeToString(),
+            headers={"Content-Type": "application/x-protobuf"},
+            timeout=5,
+        )
+        response.raise_for_status()
+
+    def send_payload_dict(self, payload_dict, signal_type):
+        payload = self._build_signal_payload_from_dict(payload_dict, signal_type)
+        endpoints = {
+            "logs": "/v1/logs",
+            "metrics": "/v1/metrics",
+            "traces": "/v1/traces",
+        }
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}{endpoints[signal_type]}",
+            data=payload.SerializeToString(),
+            headers={"Content-Type": "application/x-protobuf"},
+            timeout=5,
+        )
+        response.raise_for_status()
+
+    def _resolve_json_fixture(self, json_file):
+        return os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../../in_opentelemetry/tests/data_files",
+                json_file,
+            )
+        )
+
+    def _build_signal_payload(self, json_file, signal_type):
+        messages = {
+            "logs": ExportLogsServiceRequest(),
+            "metrics": ExportMetricsServiceRequest(),
+            "traces": ExportTraceServiceRequest(),
+        }
+        return json_format.Parse(
+            json.dumps(read_json_file(self._resolve_json_fixture(json_file))),
+            messages[signal_type],
+        )
+
+    def _build_signal_payload_from_dict(self, payload_dict, signal_type):
+        messages = {
+            "logs": ExportLogsServiceRequest(),
+            "metrics": ExportMetricsServiceRequest(),
+            "traces": ExportTraceServiceRequest(),
+        }
+        return json_format.Parse(json.dumps(payload_dict), messages[signal_type])
+
+
+def _decode_simple_msgpack(data, offset=0):
+    first = data[offset]
+    offset += 1
+
+    if first <= 0x7F:
+        return first, offset
+    if 0xA0 <= first <= 0xBF:
+        size = first & 0x1F
+        end = offset + size
+        return data[offset:end].decode("utf-8"), end
+    if 0x80 <= first <= 0x8F:
+        size = first & 0x0F
+        mapping = {}
+        for _ in range(size):
+            key, offset = _decode_simple_msgpack(data, offset)
+            value, offset = _decode_simple_msgpack(data, offset)
+            mapping[key] = value
+        return mapping, offset
+    if first == 0xC0:
+        return None, offset
+    if first == 0xC2:
+        return False, offset
+    if first == 0xC3:
+        return True, offset
+    if first == 0xCC:
+        return data[offset], offset + 1
+    if first == 0xCD:
+        return int.from_bytes(data[offset:offset + 2], "big"), offset + 2
+    if first == 0xCE:
+        return int.from_bytes(data[offset:offset + 4], "big"), offset + 4
+    if first == 0xCA:
+        return struct.unpack(">f", data[offset:offset + 4])[0], offset + 4
+    if first == 0xCB:
+        return struct.unpack(">d", data[offset:offset + 8])[0], offset + 8
+    if first == 0xD9:
+        size = data[offset]
+        offset += 1
+        end = offset + size
+        return data[offset:end].decode("utf-8"), end
+
+    raise ValueError(f"Unsupported MessagePack type 0x{first:02x}")
+
+
+def _decode_otlp_proto(data, signal_type):
+    messages = {
+        "logs": ExportLogsServiceRequest(),
+        "metrics": ExportMetricsServiceRequest(),
+        "traces": ExportTraceServiceRequest(),
+    }
+    message = messages[signal_type]
+    message.ParseFromString(data)
+    return json.loads(json_format.MessageToJson(message))
+
+
+def _resource_key(signal_type):
+    return {
+        "logs": "resource_logs",
+        "metrics": "resource_metrics",
+        "traces": "resource_spans",
+    }[signal_type]
+
+
+def _resource_key_camel(signal_type):
+    return {
+        "logs": "resourceLogs",
+        "metrics": "resourceMetrics",
+        "traces": "resourceSpans",
+    }[signal_type]
+
+
+def _load_signal_fixture(service, json_file):
+    return read_json_file(service._resolve_json_fixture(json_file))
+
+
+def _build_multi_resource_payload(service, signal_type, json_file):
+    payload = _load_signal_fixture(service, json_file)
+    key = _resource_key(signal_type)
+    resources = payload[key]
+    base = resources[0]
+
+    clone = deepcopy(base)
+    if signal_type == "logs":
+        clone["resource"]["attributes"][0]["value"]["string_value"] = "example-service-bulk"
+        clone["scope_logs"][0]["log_records"][0]["body"]["string_value"] = "bulk log resource"
+    elif signal_type == "metrics":
+        clone["resource"]["attributes"][0]["value"]["string_value"] = "instance-bulk"
+        clone["scope_metrics"][0]["metrics"][0]["name"] = "requests_total_bulk"
+    else:
+        clone["resource"]["attributes"][0]["value"]["string_value"] = "checkout-bulk"
+        clone["scope_spans"][0]["spans"][0]["name"] = "bulk-trace-span"
+
+    resources.append(clone)
+    return payload
+
+
+def _decode_kafka_payload(message, format_name, signal_type):
+    if format_name == "otlp_json":
+        return json.loads(message["value"].decode("utf-8"))
+    return _decode_otlp_proto(message["value"], signal_type)
+
+
+def _collect_resources(messages, format_name, signal_type):
+    resource_key = _resource_key_camel(signal_type)
+    resources = []
+
+    for message in messages:
+        payload = _decode_kafka_payload(message, format_name, signal_type)
+        resources.extend(payload[resource_key])
+
+    return resources
+
+
+def test_out_kafka_sends_json_payload():
+    service = Service("out_kafka_basic.yaml")
+    service.start()
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    message = messages[0]
+    assert message["topic"] == "test"
+    assert message["partition"] == 0
+    assert message["key"] is None
+
+    payload = json.loads(message["value"].decode("utf-8"))
+    assert payload["message"] == "hello from out_kafka"
+    assert payload["source"] == "dummy"
+    assert any(request["api_key"] == 3 for request in data_storage["requests"])
+    assert any(request["api_key"] == 0 for request in data_storage["requests"])
+
+
+def test_out_kafka_raw_format_uses_selected_field():
+    service = Service("out_kafka_raw.yaml")
+    service.start()
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    message = messages[0]
+    assert message["topic"] == "test"
+    assert message["value"] == b"raw value"
+
+
+def test_out_kafka_message_key_field_sets_kafka_key():
+    service = Service("out_kafka_message_key_field.yaml")
+    service.start()
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    message = messages[0]
+    assert message["topic"] == "test"
+    assert message["key"] == b"key-123"
+
+    payload = json.loads(message["value"].decode("utf-8"))
+    assert payload["message"] == "hello with key"
+    assert payload["message_key"] == "key-123"
+
+
+def test_out_kafka_dynamic_topic_routes_to_record_topic():
+    service = Service("out_kafka_dynamic_topic.yaml")
+    service.start()
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    message = messages[0]
+    assert message["topic"] == "topic-dynamic"
+
+    payload = json.loads(message["value"].decode("utf-8"))
+    assert payload["message"] == "hello dynamic topic"
+    assert payload["topic_name"] == "topic-dynamic"
+
+
+def test_out_kafka_msgpack_format_sends_msgpack_payload():
+    service = Service("out_kafka_msgpack.yaml")
+    service.start()
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    message = messages[0]
+    assert message["topic"] == "test"
+    assert message["key"] is None
+
+    payload, offset = _decode_simple_msgpack(message["value"])
+    assert offset == len(message["value"])
+    assert payload["message"] == "hello msgpack"
+    assert payload["count"] == 7
+    assert payload["source"] == "dummy"
+
+
+def test_out_kafka_otlp_json_logs():
+    service = Service("out_kafka_otlp_json.yaml")
+    service.start()
+    service.send_json_logs_payload("test_logs_001.in.json")
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    message = messages[0]
+    payload = json.loads(message["value"].decode("utf-8"))
+    record = payload["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]
+
+    assert message["topic"] == "otlp-topic"
+    assert message["key"] == b"static-otlp-key"
+    assert payload["resourceLogs"]
+    assert record["body"]["stringValue"] == "This is an example log message."
+    assert payload["resourceLogs"][0]["resource"]["attributes"][0]["key"] == "service.name"
+
+
+def test_out_kafka_otlp_json_metrics():
+    service = Service("out_kafka_otlp_json.yaml")
+    service.start()
+    service.send_json_metrics_payload("test_metrics_001.in.json")
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    message = messages[0]
+    payload = json.loads(message["value"].decode("utf-8"))
+    metric = payload["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0]
+    data_point = metric["sum"]["dataPoints"][0]
+
+    assert message["topic"] == "otlp-topic"
+    assert message["key"] == b"static-otlp-key"
+    assert payload["resourceMetrics"]
+    assert metric["name"] == "requests_total"
+    assert data_point["attributes"][0]["key"] == "service.name"
+    assert data_point["attributes"][0]["value"]["stringValue"] == "checkout"
+
+
+def test_out_kafka_otlp_json_traces():
+    service = Service("out_kafka_otlp_json.yaml")
+    service.start()
+    service.send_json_traces_payload("test_traces_001.in.json")
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    message = messages[0]
+    payload = json.loads(message["value"].decode("utf-8"))
+    span = payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+
+    assert message["topic"] == "otlp-topic"
+    assert message["key"] == b"static-otlp-key"
+    assert payload["resourceSpans"]
+    assert span["name"] == "checkout-span"
+
+
+def test_out_kafka_otlp_proto_logs():
+    service = Service("out_kafka_otlp_proto.yaml")
+    service.start()
+    service.send_json_logs_payload("test_logs_001.in.json")
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    message = messages[0]
+    payload = _decode_otlp_proto(message["value"], "logs")
+    record = payload["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0]
+
+    assert message["topic"] == "otlp-topic"
+    assert message["key"] == b"static-otlp-key"
+    assert payload["resourceLogs"]
+    assert record["body"]["stringValue"] == "This is an example log message."
+    assert payload["resourceLogs"][0]["resource"]["attributes"][0]["key"] == "service.name"
+
+
+def test_out_kafka_otlp_proto_metrics():
+    service = Service("out_kafka_otlp_proto.yaml")
+    service.start()
+    service.send_json_metrics_payload("test_metrics_001.in.json")
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    message = messages[0]
+    payload = _decode_otlp_proto(message["value"], "metrics")
+    metric = payload["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0]
+    data_point = metric["sum"]["dataPoints"][0]
+
+    assert message["topic"] == "otlp-topic"
+    assert message["key"] == b"static-otlp-key"
+    assert payload["resourceMetrics"]
+    assert metric["name"] == "requests_total"
+    assert data_point["attributes"][0]["key"] == "service.name"
+    assert data_point["attributes"][0]["value"]["stringValue"] == "checkout"
+
+
+def test_out_kafka_otlp_proto_traces():
+    service = Service("out_kafka_otlp_proto.yaml")
+    service.start()
+    service.send_json_traces_payload("test_traces_001.in.json")
+
+    messages = service.wait_for_messages(1)
+    service.stop()
+
+    message = messages[0]
+    payload = _decode_otlp_proto(message["value"], "traces")
+    span = payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+
+    assert message["topic"] == "otlp-topic"
+    assert message["key"] == b"static-otlp-key"
+    assert payload["resourceSpans"]
+    assert span["name"] == "checkout-span"
+
+
+@pytest.mark.parametrize(
+    "format_name,config_file,signal_type,json_file",
+    [
+        ("otlp_json", "out_kafka_otlp_json.yaml", "logs", "test_logs_001.in.json"),
+        ("otlp_json", "out_kafka_otlp_json.yaml", "metrics", "test_metrics_001.in.json"),
+        ("otlp_json", "out_kafka_otlp_json.yaml", "traces", "test_traces_001.in.json"),
+        ("otlp_proto", "out_kafka_otlp_proto.yaml", "logs", "test_logs_001.in.json"),
+        ("otlp_proto", "out_kafka_otlp_proto.yaml", "metrics", "test_metrics_001.in.json"),
+        ("otlp_proto", "out_kafka_otlp_proto.yaml", "traces", "test_traces_001.in.json"),
+    ],
+    ids=[
+        "otlp_json_logs",
+        "otlp_json_metrics",
+        "otlp_json_traces",
+        "otlp_proto_logs",
+        "otlp_proto_metrics",
+        "otlp_proto_traces",
+    ],
+)
+def test_out_kafka_otlp_formats_preserve_multiple_resources(
+    format_name,
+    config_file,
+    signal_type,
+    json_file,
+):
+    service = Service(config_file)
+    service.start()
+    payload_dict = _build_multi_resource_payload(service, signal_type, json_file)
+    service.send_payload_dict(payload_dict, signal_type)
+
+    expected_message_count = 2 if signal_type == "metrics" else 1
+    messages = service.wait_for_messages(expected_message_count)
+    service.stop()
+
+    resources = _collect_resources(messages, format_name, signal_type)
+
+    for message in messages:
+        assert message["topic"] == "otlp-topic"
+        assert message["key"] == b"static-otlp-key"
+
+    assert len(resources) >= 2
+
+    if signal_type == "logs":
+        bodies = [
+            record["body"]["stringValue"]
+            for resource in resources
+            for scope in resource["scopeLogs"]
+            for record in scope["logRecords"]
+        ]
+        resource_names = [
+            attribute["value"]["stringValue"]
+            for resource in resources
+            for attribute in resource["resource"]["attributes"]
+            if attribute["key"] == "service.name"
+        ]
+        assert "This is an example log message." in bodies
+        assert "bulk log resource" in bodies
+        assert "example-service-bulk" in resource_names
+    elif signal_type == "metrics":
+        metric_names = [
+            metric["name"]
+            for resource in resources
+            for scope in resource["scopeMetrics"]
+            for metric in scope["metrics"]
+        ]
+        assert "requests_total" in metric_names
+        assert "requests_total_bulk" in metric_names
+        if format_name == "otlp_json":
+            instance_ids = [
+                attribute["value"]["stringValue"]
+                for resource in resources
+                for attribute in resource["resource"]["attributes"]
+                if attribute["key"] == "service.instance.id"
+            ]
+            assert "instance-bulk" in instance_ids
+    else:
+        span_names = [
+            span["name"]
+            for resource in resources
+            for scope in resource["scopeSpans"]
+            for span in scope["spans"]
+        ]
+        service_names = [
+            attribute["value"]["stringValue"]
+            for resource in resources
+            for attribute in resource["resource"]["attributes"]
+            if attribute["key"] == "service.name"
+        ]
+        assert "checkout-span" in span_names
+        assert "bulk-trace-span" in span_names
+        assert "checkout-bulk" in service_names

--- a/scenarios/out_opentelemetry/config/out_otel_grpc_logs_oauth2_basic.yaml
+++ b/scenarios/out_opentelemetry/config/out_otel_grpc_logs_oauth2_basic.yaml
@@ -1,0 +1,28 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      samples: 1
+      dummy: |
+        {
+          "message": "hello via grpc oauth2 basic"
+        }
+
+  outputs:
+    - name: opentelemetry
+      match: "*"
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      http2: on
+      grpc: on
+      grpc_logs_uri: /custom.logs.v1.Logs/Push
+      oauth2.enable: true
+      oauth2.token_url: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token
+      oauth2.client_id: client1
+      oauth2.client_secret: secret1
+      oauth2.scope: logs.write

--- a/scenarios/out_opentelemetry/config/out_otel_grpc_logs_oauth2_private_key_jwt.yaml
+++ b/scenarios/out_opentelemetry/config/out_otel_grpc_logs_oauth2_private_key_jwt.yaml
@@ -1,0 +1,30 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      samples: 1
+      dummy: |
+        {
+          "message": "hello via grpc oauth2 private key jwt"
+        }
+
+  outputs:
+    - name: opentelemetry
+      match: "*"
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      http2: on
+      grpc: on
+      grpc_logs_uri: /custom.logs.v1.Logs/Push
+      oauth2.enable: true
+      oauth2.token_url: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token
+      oauth2.client_id: client1
+      oauth2.auth_method: private_key_jwt
+      oauth2.jwt_key_file: ${PRIVATE_KEY_TEST}
+      oauth2.jwt_cert_file: ${CERTIFICATE_TEST}
+      oauth2.jwt_aud: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token

--- a/scenarios/out_opentelemetry/config/out_otel_http_logs_oauth2_basic.yaml
+++ b/scenarios/out_opentelemetry/config/out_otel_http_logs_oauth2_basic.yaml
@@ -1,0 +1,27 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      samples: 1
+      dummy: |
+        {
+          "message": "hello from out_opentelemetry oauth2 basic",
+          "source": "dummy"
+        }
+
+  outputs:
+    - name: opentelemetry
+      match: "*"
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      logs_uri: /custom/logs
+      oauth2.enable: true
+      oauth2.token_url: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token
+      oauth2.client_id: client1
+      oauth2.client_secret: secret1
+      oauth2.scope: logs.write

--- a/scenarios/out_opentelemetry/config/out_otel_http_logs_oauth2_private_key_jwt.yaml
+++ b/scenarios/out_opentelemetry/config/out_otel_http_logs_oauth2_private_key_jwt.yaml
@@ -1,0 +1,29 @@
+service:
+  flush: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      samples: 1
+      dummy: |
+        {
+          "message": "hello from out_opentelemetry oauth2 jwt",
+          "source": "dummy"
+        }
+
+  outputs:
+    - name: opentelemetry
+      match: "*"
+      host: 127.0.0.1
+      port: ${TEST_SUITE_HTTP_PORT}
+      logs_uri: /custom/logs
+      oauth2.enable: true
+      oauth2.token_url: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token
+      oauth2.client_id: client1
+      oauth2.auth_method: private_key_jwt
+      oauth2.jwt_key_file: ${PRIVATE_KEY_TEST}
+      oauth2.jwt_cert_file: ${CERTIFICATE_TEST}
+      oauth2.jwt_aud: http://127.0.0.1:${TEST_SUITE_OAUTH_PORT}/oauth/token

--- a/scenarios/out_opentelemetry/tests/test_out_opentelemetry_001.py
+++ b/scenarios/out_opentelemetry/tests/test_out_opentelemetry_001.py
@@ -5,11 +5,17 @@ import os
 import socket
 
 import requests
+import pytest
 from google.protobuf import json_format
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 
+from server.http_server import (
+    configure_oauth_token_response,
+    data_storage as http_data_storage,
+    http_server_run,
+)
 from server.otlp_server import (
     configure_otlp_grpc_methods,
     data_storage,
@@ -55,7 +61,15 @@ def iter_metric_attributes(output):
 
 
 class Service:
-    def __init__(self, config_file, *, receiver_mode="http", use_tls=False, grpc_methods=None):
+    def __init__(
+        self,
+        config_file,
+        *,
+        receiver_mode="http",
+        use_tls=False,
+        grpc_methods=None,
+        use_oauth_server=False,
+    ):
         self.config_file = _repo_relative("../config", config_file)
         cert_dir = _repo_relative("../../in_splunk/certificate")
         self.tls_crt_file = os.path.join(cert_dir, "certificate.pem")
@@ -63,6 +77,8 @@ class Service:
         self.receiver_mode = receiver_mode
         self.use_tls = use_tls
         self.grpc_methods = grpc_methods or {}
+        self.use_oauth_server = use_oauth_server
+        self.oauth_server_port = None
         self.service = FluentBitTestService(
             self.config_file,
             data_storage=data_storage,
@@ -89,6 +105,15 @@ class Service:
         )
 
     def _start_receiver(self, service):
+        if self.use_oauth_server:
+            self.oauth_server_port = service.allocate_port_env("TEST_SUITE_OAUTH_PORT")
+            http_server_run(self.oauth_server_port)
+            self.service.wait_for_http_endpoint(
+                f"http://127.0.0.1:{self.oauth_server_port}/ping",
+                timeout=10,
+                interval=0.5,
+            )
+
         configure_otlp_grpc_methods(**self.grpc_methods)
         otlp_server_run(
             service.test_suite_http_port,
@@ -124,6 +149,11 @@ class Service:
         )
 
     def _stop_receiver(self, service):
+        if self.oauth_server_port is not None:
+            try:
+                requests.post(f"http://127.0.0.1:{self.oauth_server_port}/shutdown", timeout=2)
+            except requests.RequestException:
+                pass
         stop_otlp_server()
 
     def start(self):
@@ -141,6 +171,14 @@ class Service:
             timeout=timeout,
             interval=0.5,
             description=f"{minimum_count} OTLP requests",
+        )
+
+    def wait_for_oauth_requests(self, minimum_count, timeout=10):
+        return self.service.wait_for_condition(
+            lambda: http_data_storage["requests"] if len(http_data_storage["requests"]) >= minimum_count else None,
+            timeout=timeout,
+            interval=0.5,
+            description=f"{minimum_count} OAuth requests",
         )
 
     def wait_for_signal(self, signal_type, minimum_count=1, timeout=10):
@@ -207,6 +245,86 @@ def test_out_opentelemetry_http_logs_uri_headers_and_basic_auth():
     assert request_seen["headers"]["X-Suite"] == "otel-test"
     assert base64.b64decode(record["traceId"]) == bytes.fromhex("63560bd4d8de74fae7d1e4160f2ee099")
     assert base64.b64decode(record["spanId"]) == bytes.fromhex("251484295a9df731")
+
+
+@pytest.mark.parametrize(
+    "config_file,auth_mode",
+    [
+        ("out_otel_http_logs_oauth2_basic.yaml", "basic"),
+        ("out_otel_http_logs_oauth2_private_key_jwt.yaml", "private_key_jwt"),
+    ],
+    ids=["oauth2_basic", "oauth2_private_key_jwt"],
+)
+def test_out_opentelemetry_http_logs_oauth2_auth_matrix(config_file, auth_mode):
+    service = Service(config_file, use_oauth_server=True)
+    service.start()
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    token_requests = service.wait_for_oauth_requests(1)
+    otlp_requests = service.wait_for_requests(1)
+    service.stop()
+
+    token_request = next(request for request in token_requests if request["path"] == "/oauth/token")
+    data_request = next(request for request in otlp_requests if request["path"] == "/custom/logs")
+
+    assert token_request["method"] == "POST"
+    assert "grant_type=client_credentials" in token_request["raw_data"]
+    assert data_request["headers"].get("Authorization") == "Bearer oauth-access-token"
+
+    if auth_mode == "basic":
+        assert "Basic " in token_request["headers"].get("Authorization", "")
+        assert "scope=logs.write" in token_request["raw_data"]
+        return
+
+    assert "client_assertion_type=" in token_request["raw_data"]
+    assert "client_assertion=" in token_request["raw_data"]
+    assert "client_id=client1" in token_request["raw_data"]
+
+
+@pytest.mark.parametrize(
+    "config_file,auth_mode",
+    [
+        ("out_otel_grpc_logs_oauth2_basic.yaml", "basic"),
+        ("out_otel_grpc_logs_oauth2_private_key_jwt.yaml", "private_key_jwt"),
+    ],
+    ids=["grpc_oauth2_basic", "grpc_oauth2_private_key_jwt"],
+)
+def test_out_opentelemetry_grpc_logs_oauth2_auth_matrix(config_file, auth_mode):
+    service = Service(
+        config_file,
+        receiver_mode="grpc",
+        grpc_methods={"logs": "/custom.logs.v1.Logs/Push"},
+        use_oauth_server=True,
+    )
+    service.start()
+    configure_oauth_token_response(
+        status_code=200,
+        body={"access_token": "oauth-access-token", "token_type": "Bearer", "expires_in": 300},
+    )
+
+    token_requests = service.wait_for_oauth_requests(1)
+    otlp_requests = service.wait_for_requests(1)
+    service.stop()
+
+    token_request = next(request for request in token_requests if request["path"] == "/oauth/token")
+    data_request = next(request for request in otlp_requests if request["path"] == "/custom.logs.v1.Logs/Push")
+
+    assert token_request["method"] == "POST"
+    assert "grant_type=client_credentials" in token_request["raw_data"]
+    assert data_request["transport"] == "grpc"
+    assert data_request["headers"].get("authorization") == "Bearer oauth-access-token"
+
+    if auth_mode == "basic":
+        assert "Basic " in token_request["headers"].get("Authorization", "")
+        assert "scope=logs.write" in token_request["raw_data"]
+        return
+
+    assert "client_assertion_type=" in token_request["raw_data"]
+    assert "client_assertion=" in token_request["raw_data"]
+    assert "client_id=client1" in token_request["raw_data"]
 
 
 def test_out_opentelemetry_gzip_and_logs_body_key_attributes():

--- a/scenarios/out_s3/config/out_s3_basic.yaml
+++ b/scenarios/out_s3/config/out_s3_basic.yaml
@@ -1,0 +1,26 @@
+service:
+  flush: 1
+  grace: 3
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_s3
+      dummy: '{"message":"hello from out_s3","source":"dummy"}'
+      samples: 1
+
+  outputs:
+    - name: s3
+      match: out_s3
+      bucket: test-bucket
+      region: us-east-1
+      endpoint: http://127.0.0.1:${TEST_SUITE_HTTP_PORT}
+      use_put_object: true
+      total_file_size: 1M
+      upload_timeout: 2s
+      s3_key_format: /payloads/$TAG/$UUID
+      content_type: application/x-ndjson
+      store_dir: /tmp/fluent-bit-test-suite-s3-basic

--- a/scenarios/out_s3/config/out_s3_format_json.yaml
+++ b/scenarios/out_s3/config/out_s3_format_json.yaml
@@ -1,0 +1,27 @@
+service:
+  flush: 1
+  grace: 3
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_s3
+      dummy: '{"message":"hello from out_s3 format json","source":"dummy"}'
+      samples: 1
+
+  outputs:
+    - name: s3
+      match: out_s3
+      bucket: test-bucket
+      region: us-east-1
+      endpoint: http://127.0.0.1:${TEST_SUITE_HTTP_PORT}
+      use_put_object: true
+      total_file_size: 1M
+      upload_timeout: 2s
+      s3_key_format: /payloads/$TAG/$UUID
+      format: json
+      content_type: application/x-ndjson
+      store_dir: /tmp/fluent-bit-test-suite-s3-format-json

--- a/scenarios/out_s3/config/out_s3_gzip.yaml
+++ b/scenarios/out_s3/config/out_s3_gzip.yaml
@@ -1,0 +1,27 @@
+service:
+  flush: 1
+  grace: 3
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: out_s3
+      dummy: '{"message":"hello gzip s3","source":"dummy"}'
+      samples: 1
+
+  outputs:
+    - name: s3
+      match: out_s3
+      bucket: test-bucket
+      region: us-east-1
+      endpoint: http://127.0.0.1:${TEST_SUITE_HTTP_PORT}
+      use_put_object: true
+      total_file_size: 1M
+      upload_timeout: 2s
+      s3_key_format: /payloads/$TAG/$UUID
+      content_type: application/x-ndjson
+      compression: gzip
+      store_dir: /tmp/fluent-bit-test-suite-s3-gzip

--- a/scenarios/out_s3/config/out_s3_otlp_json.yaml
+++ b/scenarios/out_s3/config/out_s3_otlp_json.yaml
@@ -1,0 +1,26 @@
+service:
+  flush: 1
+  grace: 3
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      listen: 127.0.0.1
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: s3
+      match: "*"
+      bucket: test-bucket
+      region: us-east-1
+      endpoint: http://127.0.0.1:${TEST_SUITE_HTTP_PORT}
+      use_put_object: true
+      total_file_size: 1M
+      upload_timeout: 2s
+      s3_key_format: /payloads/$TAG/$UUID
+      format: otlp_json
+      content_type: application/json
+      store_dir: /tmp/fluent-bit-test-suite-s3-otlp-json

--- a/scenarios/out_s3/tests/test_out_s3_001.py
+++ b/scenarios/out_s3/tests/test_out_s3_001.py
@@ -1,0 +1,215 @@
+import gzip
+import json
+import os
+
+import requests
+import pytest
+from google.protobuf import json_format
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+from server.s3_server import data_storage, s3_server_run, s3_server_stop
+from utils.data_utils import read_json_file
+from utils.fluent_bit_manager import FluentBitStartupError
+from utils.test_service import FluentBitTestService
+
+
+class Service:
+    def __init__(self, config_file):
+        self.config_file = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "../config", config_file)
+        )
+        self.service = FluentBitTestService(
+            self.config_file,
+            data_storage=data_storage,
+            data_keys=["requests"],
+            extra_env={
+                "AWS_ACCESS_KEY_ID": "test-access-key",
+                "AWS_SECRET_ACCESS_KEY": "test-secret-key",
+                "AWS_EC2_METADATA_DISABLED": "true",
+            },
+            pre_start=self._start_receiver,
+            post_stop=self._stop_receiver,
+        )
+
+    def _start_receiver(self, service):
+        self.s3_port = service.allocate_port_env("TEST_SUITE_HTTP_PORT")
+        s3_server_run(self.s3_port)
+
+    def _stop_receiver(self, service):
+        s3_server_stop()
+
+    def start(self):
+        self.service.start()
+        self.flb_listener_port = self.service.flb_listener_port
+
+    def stop(self):
+        self.service.stop()
+
+    def wait_for_request(self, index=0):
+        return self.service.wait_for_condition(
+            lambda: data_storage["requests"][index] if len(data_storage["requests"]) > index else None,
+            timeout=15,
+            interval=0.5,
+            description=f"S3 upload request {index}",
+        )
+
+    def _resolve_json_fixture(self, json_file):
+        return os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../../in_opentelemetry/tests/data_files",
+                json_file,
+            )
+        )
+
+    def _build_signal_payload(self, json_file, signal_type):
+        messages = {
+            "logs": ExportLogsServiceRequest(),
+            "metrics": ExportMetricsServiceRequest(),
+            "traces": ExportTraceServiceRequest(),
+        }
+        return json_format.Parse(
+            json.dumps(read_json_file(self._resolve_json_fixture(json_file))),
+            messages[signal_type],
+        )
+
+    def send_logs_payload(self, json_file):
+        payload = self._build_signal_payload(json_file, "logs")
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}/v1/logs",
+            data=payload.SerializeToString(),
+            headers={"Content-Type": "application/x-protobuf"},
+            timeout=5,
+        )
+        response.raise_for_status()
+
+    def send_metrics_payload(self, json_file):
+        payload = self._build_signal_payload(json_file, "metrics")
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}/v1/metrics",
+            data=payload.SerializeToString(),
+            headers={"Content-Type": "application/x-protobuf"},
+            timeout=5,
+        )
+        response.raise_for_status()
+
+    def send_traces_payload(self, json_file):
+        payload = self._build_signal_payload(json_file, "traces")
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}/v1/traces",
+            data=payload.SerializeToString(),
+            headers={"Content-Type": "application/x-protobuf"},
+            timeout=5,
+        )
+        response.raise_for_status()
+
+
+def _parse_json_lines(body):
+    lines = [line for line in body.decode("utf-8").splitlines() if line.strip()]
+    return [json.loads(line) for line in lines]
+
+
+def _parse_single_json_payload(body):
+    return json.loads(body.decode("utf-8").strip())
+
+
+def _send_otlp_signal(service, signal_type, json_file):
+    if signal_type == "logs":
+        service.send_logs_payload(json_file)
+    elif signal_type == "metrics":
+        service.send_metrics_payload(json_file)
+    else:
+        service.send_traces_payload(json_file)
+
+
+def _start_or_skip_unsupported_s3_format(service, format_name):
+    try:
+        service.start()
+    except FluentBitStartupError:
+        log_contents = ""
+        if service.service.flb and service.service.flb.log_file:
+            with open(service.service.flb.log_file, "r", encoding="utf-8", errors="replace") as file:
+                log_contents = file.read()
+        if f"unknown configuration property '{format_name}'" in log_contents:
+            pytest.skip(f"s3.{format_name} is not supported by this Fluent Bit binary")
+        raise
+
+
+def test_out_s3_put_object_uploads_json_lines_payload():
+    service = Service("out_s3_basic.yaml")
+    service.start()
+    request = service.wait_for_request()
+    service.stop()
+
+    assert request["method"] == "PUT"
+    assert request["path"].startswith("/test-bucket/payloads/out_s3/")
+    assert request["headers"]["Content-Type"] == "application/x-ndjson"
+
+    payload = _parse_json_lines(request["body"])
+    assert len(payload) == 1
+    assert payload[0]["message"] == "hello from out_s3"
+    assert payload[0]["source"] == "dummy"
+    assert "date" in payload[0]
+
+
+def test_out_s3_format_json_uploads_logs_only_as_json_lines():
+    service = Service("out_s3_format_json.yaml")
+    _start_or_skip_unsupported_s3_format(service, "format")
+    request = service.wait_for_request()
+    service.stop()
+
+    assert request["method"] == "PUT"
+    assert request["path"].startswith("/test-bucket/payloads/out_s3/")
+    assert request["headers"]["Content-Type"] == "application/x-ndjson"
+
+    payload = _parse_json_lines(request["body"])
+    assert len(payload) == 1
+    assert payload[0]["message"] == "hello from out_s3 format json"
+    assert payload[0]["source"] == "dummy"
+    assert "date" in payload[0]
+
+
+def test_out_s3_put_object_gzip_upload_sets_encoding_and_compresses_payload():
+    service = Service("out_s3_gzip.yaml")
+    service.start()
+    request = service.wait_for_request()
+    service.stop()
+
+    assert request["method"] == "PUT"
+    assert request["path"].startswith("/test-bucket/payloads/out_s3/")
+    assert request["headers"]["Content-Type"] == "application/x-ndjson"
+    assert request["headers"]["Content-Encoding"] == "gzip"
+
+    payload = _parse_json_lines(gzip.decompress(request["body"]))
+    assert len(payload) == 1
+    assert payload[0]["message"] == "hello gzip s3"
+    assert payload[0]["source"] == "dummy"
+    assert "date" in payload[0]
+
+
+@pytest.mark.parametrize(
+    ("signal_type", "json_file", "root_key", "expected_value"),
+    [
+        ("logs", "test_logs_001.in.json", "resourceLogs", "This is an example log message."),
+        ("metrics", "test_metrics_001.in.json", "resourceMetrics", "requests_total"),
+        ("traces", "test_traces_001.in.json", "resourceSpans", "checkout-span"),
+    ],
+)
+def test_out_s3_otlp_json_uploads_signal_payloads(signal_type, json_file, root_key, expected_value):
+    service = Service("out_s3_otlp_json.yaml")
+    _start_or_skip_unsupported_s3_format(service, "format")
+    _send_otlp_signal(service, signal_type, json_file)
+    request = service.wait_for_request()
+    service.stop()
+
+    assert request["method"] == "PUT"
+    assert request["path"].startswith("/test-bucket/payloads/")
+    assert request["headers"]["Content-Type"] == "application/json"
+
+    payload = _parse_single_json_payload(request["body"])
+    assert root_key in payload
+
+    rendered = json.dumps(payload)
+    assert expected_value in rendered

--- a/scenarios/out_stdout/config/out_stdout_basic.yaml
+++ b/scenarios/out_stdout/config/out_stdout_basic.yaml
@@ -1,0 +1,17 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: stdout.logs
+      dummy: '{"message":"hello from out_stdout","source":"dummy"}'
+      samples: 1
+
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/out_stdout/config/out_stdout_json_lines.yaml
+++ b/scenarios/out_stdout/config/out_stdout_json_lines.yaml
@@ -1,0 +1,20 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: dummy
+      tag: stdout.json
+      dummy: '{"message":"hello json lines","source":"dummy"}'
+      samples: 1
+
+  outputs:
+    - name: stdout
+      match: '*'
+      format: json_lines
+      json_date_key: timestamp
+      json_date_format: iso8601

--- a/scenarios/out_stdout/config/out_stdout_metrics.yaml
+++ b/scenarios/out_stdout/config/out_stdout_metrics.yaml
@@ -1,0 +1,15 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/out_stdout/config/out_stdout_otel.yaml
+++ b/scenarios/out_stdout/config/out_stdout_otel.yaml
@@ -1,0 +1,15 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/out_stdout/config/out_stdout_traces.yaml
+++ b/scenarios/out_stdout/config/out_stdout_traces.yaml
@@ -1,0 +1,15 @@
+service:
+  flush: 1
+  grace: 1
+  log_level: info
+  http_server: on
+  http_port: ${FLUENT_BIT_HTTP_MONITORING_PORT}
+
+pipeline:
+  inputs:
+    - name: opentelemetry
+      port: ${FLUENT_BIT_TEST_LISTENER_PORT}
+
+  outputs:
+    - name: stdout
+      match: '*'

--- a/scenarios/out_stdout/tests/test_out_stdout_001.py
+++ b/scenarios/out_stdout/tests/test_out_stdout_001.py
@@ -1,0 +1,204 @@
+import json
+import os
+
+import requests
+from google.protobuf import json_format
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+from utils.data_utils import read_json_file, read_file
+from utils.test_service import FluentBitTestService
+
+
+class Service:
+    def __init__(self, config_file):
+        self.config_file = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "../config", config_file)
+        )
+        self.service = FluentBitTestService(self.config_file)
+
+    def start(self):
+        self.service.start()
+        self.flb = self.service.flb
+        self.flb_listener_port = self.service.flb_listener_port
+
+    def stop(self):
+        self.service.stop()
+
+    def wait_for_log_contains(self, text, timeout=10):
+        return self.service.wait_for_condition(
+            lambda: read_file(self.flb.log_file) if text in read_file(self.flb.log_file) else None,
+            timeout=timeout,
+            interval=0.5,
+            description=f"log text {text!r}",
+        )
+
+    def read_log(self):
+        return read_file(self.flb.log_file)
+
+    def _resolve_json_fixture(self, json_file):
+        return os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../../in_opentelemetry/tests/data_files",
+                json_file,
+            )
+        )
+
+    def _build_metrics_payload(self, json_file):
+        return json_format.Parse(
+            json.dumps(read_json_file(self._resolve_json_fixture(json_file))),
+            ExportMetricsServiceRequest(),
+        )
+
+    def _build_traces_payload(self, json_file):
+        return json_format.Parse(
+            json.dumps(read_json_file(self._resolve_json_fixture(json_file))),
+            ExportTraceServiceRequest(),
+        )
+
+    def _build_logs_payload(self, json_file):
+        return json_format.Parse(
+            json.dumps(read_json_file(self._resolve_json_fixture(json_file))),
+            ExportLogsServiceRequest(),
+        )
+
+    def send_json_metrics_payload(self, json_file):
+        payload = self._build_metrics_payload(json_file)
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}/v1/metrics",
+            data=payload.SerializeToString(),
+            headers={"Content-Type": "application/x-protobuf"},
+            timeout=5,
+        )
+        response.raise_for_status()
+
+    def send_json_traces_payload(self, json_file):
+        payload = self._build_traces_payload(json_file)
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}/v1/traces",
+            data=payload.SerializeToString(),
+            headers={"Content-Type": "application/x-protobuf"},
+            timeout=5,
+        )
+        response.raise_for_status()
+
+    def send_logs_json_payload(self, json_file):
+        payload = self._build_logs_payload(json_file)
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}/v1/logs",
+            data=json_format.MessageToJson(payload),
+            headers={"Content-Type": "application/json"},
+            timeout=5,
+        )
+        response.raise_for_status()
+
+    def send_metrics_json_payload(self, json_file):
+        payload = self._build_metrics_payload(json_file)
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}/v1/metrics",
+            data=json_format.MessageToJson(payload),
+            headers={"Content-Type": "application/json"},
+            timeout=5,
+        )
+        response.raise_for_status()
+
+    def send_traces_json_payload(self, json_file):
+        payload = self._build_traces_payload(json_file)
+        response = requests.post(
+            f"http://127.0.0.1:{self.flb_listener_port}/v1/traces",
+            data=json_format.MessageToJson(payload),
+            headers={"Content-Type": "application/json"},
+            timeout=5,
+        )
+        response.raise_for_status()
+
+
+def _find_json_line(log_text, needle):
+    for line in log_text.splitlines():
+        if needle in line and line.lstrip().startswith("{"):
+            return json.loads(line)
+    raise AssertionError(f"Could not find JSON line containing {needle!r}")
+
+
+def test_out_stdout_default_format_emits_tagged_log_line():
+    service = Service("out_stdout_basic.yaml")
+    service.start()
+    log_text = service.wait_for_log_contains("hello from out_stdout")
+    service.stop()
+
+    assert "[0] stdout.logs:" in log_text
+    assert "hello from out_stdout" in log_text
+    assert "\"source\"=>\"dummy\"" in log_text or '"source"' in log_text
+
+
+def test_out_stdout_json_lines_honors_date_key_and_json_format():
+    service = Service("out_stdout_json_lines.yaml")
+    service.start()
+    log_text = service.wait_for_log_contains("hello json lines")
+    service.stop()
+
+    payload = _find_json_line(log_text, "hello json lines")
+    assert payload["message"] == "hello json lines"
+    assert payload["source"] == "dummy"
+    assert "timestamp" in payload
+    assert "T" in payload["timestamp"]
+
+
+def test_out_stdout_metrics_emits_text_representation():
+    service = Service("out_stdout_metrics.yaml")
+    service.start()
+    service.send_json_metrics_payload("test_metrics_001.in.json")
+    log_text = service.wait_for_log_contains("requests_total")
+    service.stop()
+
+    assert "requests_total" in log_text
+    assert "service.name=\"checkout\"" in log_text
+    assert "= 42" in log_text
+
+
+def test_out_stdout_traces_emits_text_representation():
+    service = Service("out_stdout_traces.yaml")
+    service.start()
+    service.send_json_traces_payload("test_traces_001.in.json")
+    log_text = service.wait_for_log_contains("checkout-span")
+    service.stop()
+
+    assert "checkout-span" in log_text
+    assert "trace-scope" in log_text
+    assert "service.name" in log_text or "checkout" in log_text
+
+
+def test_out_stdout_logs_accepts_otlp_json_ingestion():
+    service = Service("out_stdout_otel.yaml")
+    service.start()
+    service.send_logs_json_payload("test_logs_001.in.json")
+    log_text = service.wait_for_log_contains("This is an example log message.")
+    service.stop()
+
+    assert "This is an example log message." in log_text
+    assert "This is another example log message." in log_text
+
+
+def test_out_stdout_metrics_accepts_otlp_json_ingestion():
+    service = Service("out_stdout_otel.yaml")
+    service.start()
+    service.send_metrics_json_payload("test_metrics_001.in.json")
+    log_text = service.wait_for_log_contains("requests_total")
+    service.stop()
+
+    assert "requests_total" in log_text
+    assert "service.name=\"checkout\"" in log_text
+    assert "= 42" in log_text
+
+
+def test_out_stdout_traces_accepts_otlp_json_ingestion():
+    service = Service("out_stdout_otel.yaml")
+    service.start()
+    service.send_traces_json_payload("test_traces_001.in.json")
+    log_text = service.wait_for_log_contains("checkout-span")
+    service.stop()
+
+    assert "checkout-span" in log_text
+    assert "trace-scope" in log_text

--- a/setup-venv.sh
+++ b/setup-venv.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="${SCRIPT_DIR}/.venv"
+PYTHON_BIN="${PYTHON:-python3}"
+
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+    echo "error: ${PYTHON_BIN} was not found in PATH" >&2
+    exit 1
+fi
+
+if [[ ! -d "${VENV_DIR}" ]]; then
+    "${PYTHON_BIN}" -m venv "${VENV_DIR}"
+fi
+
+"${VENV_DIR}/bin/python3" -m pip install --upgrade pip
+"${VENV_DIR}/bin/python3" -m pip install -r "${SCRIPT_DIR}/requirements.txt"
+
+cat <<EOF
+Python test environment is ready.
+
+Next steps:
+  ${SCRIPT_DIR}/run_tests.py --list
+  ${SCRIPT_DIR}/run_tests.py
+EOF

--- a/src/server/forward_server.py
+++ b/src/server/forward_server.py
@@ -1,0 +1,397 @@
+#  Fluent Bit
+#  ==========
+#  Copyright (C) 2015-2026 The Fluent Bit Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import gzip
+import logging
+import socket
+import struct
+import subprocess
+import threading
+import time
+
+
+logger = logging.getLogger(__name__)
+
+data_storage = {
+    "messages": [],
+    "connections": [],
+}
+
+server_thread = None
+server_port = None
+server_stop_event = threading.Event()
+
+
+class IncompleteBuffer(Exception):
+    pass
+
+
+def reset_forward_server_state():
+    data_storage["messages"] = []
+    data_storage["connections"] = []
+    server_stop_event.clear()
+
+
+def _decode_str_like(raw):
+    try:
+        return raw.decode()
+    except UnicodeDecodeError:
+        return raw
+
+
+def _require_bytes(data, offset, size):
+    end = offset + size
+    if end > len(data):
+        raise IncompleteBuffer()
+    return end
+
+
+def _unpack_array(data, offset, size):
+    result = []
+    for _ in range(size):
+        value, offset = _unpack_obj(data, offset)
+        result.append(value)
+    return result, offset
+
+
+def _unpack_map(data, offset, size):
+    result = {}
+    for _ in range(size):
+        key, offset = _unpack_obj(data, offset)
+        value, offset = _unpack_obj(data, offset)
+        result[key] = value
+    return result, offset
+
+
+def _unpack_ext(data, offset, payload_size):
+    end = _require_bytes(data, offset, 1 + payload_size)
+    ext_type = int.from_bytes(data[offset:offset + 1], "big", signed=True)
+    payload_offset = offset + 1
+    return {"__ext__": {"type": ext_type, "data": data[payload_offset:end]}}, end
+
+
+def _unpack_obj(data, offset):
+    if offset >= len(data):
+        raise IncompleteBuffer()
+
+    first = data[offset]
+    offset += 1
+
+    if first <= 0x7F:
+        return first, offset
+    if first >= 0xE0:
+        return first - 0x100, offset
+    if 0x80 <= first <= 0x8F:
+        return _unpack_map(data, offset, first & 0x0F)
+    if 0x90 <= first <= 0x9F:
+        return _unpack_array(data, offset, first & 0x0F)
+    if 0xA0 <= first <= 0xBF:
+        size = first & 0x1F
+        end = _require_bytes(data, offset, size)
+        raw = data[offset:end]
+        return _decode_str_like(raw), end
+    if first == 0xC0:
+        return None, offset
+    if first == 0xC2:
+        return False, offset
+    if first == 0xC3:
+        return True, offset
+    if first == 0xC4:
+        _require_bytes(data, offset, 1)
+        size = data[offset]
+        offset += 1
+        end = _require_bytes(data, offset, size)
+        return data[offset:end], end
+    if first == 0xC5:
+        _require_bytes(data, offset, 2)
+        size = int.from_bytes(data[offset:offset + 2], "big")
+        offset += 2
+        end = _require_bytes(data, offset, size)
+        return data[offset:end], end
+    if first == 0xC6:
+        _require_bytes(data, offset, 4)
+        size = int.from_bytes(data[offset:offset + 4], "big")
+        offset += 4
+        end = _require_bytes(data, offset, size)
+        return data[offset:end], end
+    if first == 0xCA:
+        _require_bytes(data, offset, 4)
+        return struct.unpack(">f", data[offset:offset + 4])[0], offset + 4
+    if first == 0xCB:
+        _require_bytes(data, offset, 8)
+        return struct.unpack(">d", data[offset:offset + 8])[0], offset + 8
+    if first == 0xCC:
+        _require_bytes(data, offset, 1)
+        return data[offset], offset + 1
+    if first == 0xCD:
+        _require_bytes(data, offset, 2)
+        return int.from_bytes(data[offset:offset + 2], "big"), offset + 2
+    if first == 0xCE:
+        _require_bytes(data, offset, 4)
+        return int.from_bytes(data[offset:offset + 4], "big"), offset + 4
+    if first == 0xCF:
+        _require_bytes(data, offset, 8)
+        return int.from_bytes(data[offset:offset + 8], "big"), offset + 8
+    if first == 0xD0:
+        _require_bytes(data, offset, 1)
+        return int.from_bytes(data[offset:offset + 1], "big", signed=True), offset + 1
+    if first == 0xD1:
+        _require_bytes(data, offset, 2)
+        return int.from_bytes(data[offset:offset + 2], "big", signed=True), offset + 2
+    if first == 0xD2:
+        _require_bytes(data, offset, 4)
+        return int.from_bytes(data[offset:offset + 4], "big", signed=True), offset + 4
+    if first == 0xD3:
+        _require_bytes(data, offset, 8)
+        return int.from_bytes(data[offset:offset + 8], "big", signed=True), offset + 8
+    if first == 0xD4:
+        return _unpack_ext(data, offset, 1)
+    if first == 0xD5:
+        return _unpack_ext(data, offset, 2)
+    if first == 0xD6:
+        return _unpack_ext(data, offset, 4)
+    if first == 0xD7:
+        return _unpack_ext(data, offset, 8)
+    if first == 0xD8:
+        return _unpack_ext(data, offset, 16)
+    if first == 0xD9:
+        _require_bytes(data, offset, 1)
+        size = data[offset]
+        offset += 1
+        end = _require_bytes(data, offset, size)
+        return _decode_str_like(data[offset:end]), end
+    if first == 0xDA:
+        _require_bytes(data, offset, 2)
+        size = int.from_bytes(data[offset:offset + 2], "big")
+        offset += 2
+        end = _require_bytes(data, offset, size)
+        return _decode_str_like(data[offset:end]), end
+    if first == 0xDB:
+        _require_bytes(data, offset, 4)
+        size = int.from_bytes(data[offset:offset + 4], "big")
+        offset += 4
+        end = _require_bytes(data, offset, size)
+        return _decode_str_like(data[offset:end]), end
+    if first == 0xDC:
+        _require_bytes(data, offset, 2)
+        size = int.from_bytes(data[offset:offset + 2], "big")
+        return _unpack_array(data, offset + 2, size)
+    if first == 0xDD:
+        _require_bytes(data, offset, 4)
+        size = int.from_bytes(data[offset:offset + 4], "big")
+        return _unpack_array(data, offset + 4, size)
+    if first == 0xDE:
+        _require_bytes(data, offset, 2)
+        size = int.from_bytes(data[offset:offset + 2], "big")
+        return _unpack_map(data, offset + 2, size)
+    if first == 0xDF:
+        _require_bytes(data, offset, 4)
+        size = int.from_bytes(data[offset:offset + 4], "big")
+        return _unpack_map(data, offset + 4, size)
+
+    raise ValueError(f"Unsupported MessagePack type 0x{first:02x}")
+
+
+def _pack_str(value):
+    data = value.encode()
+    length = len(data)
+    if length <= 31:
+        return bytes([0xA0 | length]) + data
+    if length <= 0xFF:
+        return b"\xD9" + bytes([length]) + data
+    return b"\xDA" + length.to_bytes(2, "big") + data
+
+
+def _pack_map(mapping):
+    items = list(mapping.items())
+    prefix = bytes([0x80 | len(items)])
+    encoded = []
+    for key, value in items:
+        encoded.append(_pack_obj(key))
+        encoded.append(_pack_obj(value))
+    return prefix + b"".join(encoded)
+
+
+def _pack_obj(value):
+    if isinstance(value, str):
+        return _pack_str(value)
+    if isinstance(value, bytes):
+        length = len(value)
+        if length <= 0xFF:
+            return b"\xC4" + bytes([length]) + value
+        return b"\xC5" + length.to_bytes(2, "big") + value
+    if isinstance(value, dict):
+        return _pack_map(value)
+    raise TypeError(f"Unsupported pack type {type(value)!r}")
+
+
+def _send_ack(sock, chunk):
+    sock.sendall(_pack_obj({"ack": chunk}))
+
+
+def _decode_packed_entries(entry, options):
+    payload = entry
+    if options.get("compressed") == "gzip":
+        payload = gzip.decompress(payload)
+    elif options.get("compressed") == "zstd":
+        result = subprocess.run(
+            ["zstd", "-d", "-c"],
+            input=payload,
+            capture_output=True,
+            check=True,
+        )
+        payload = result.stdout
+
+    records = []
+    offset = 0
+    while offset < len(payload):
+        value, offset = _unpack_obj(payload, offset)
+        records.append(_normalize_forward_record(value))
+    return records
+
+
+def _normalize_forward_record(entry):
+    if not isinstance(entry, list):
+        return {"raw": entry}
+
+    if (
+        len(entry) == 2 and
+        isinstance(entry[0], list) and
+        len(entry[0]) == 2
+    ):
+        return {
+            "timestamp": entry[0][0],
+            "metadata": entry[0][1],
+            "body": entry[1],
+            "raw": entry,
+        }
+
+    if len(entry) == 2:
+        return {"timestamp": entry[0], "body": entry[1], "metadata": None, "raw": entry}
+    if len(entry) == 3:
+        return {"timestamp": entry[0], "metadata": entry[1], "body": entry[2], "raw": entry}
+
+    return {"raw": entry}
+
+
+def _classify_message(root):
+    tag = root[0] if isinstance(root, list) and len(root) > 0 else None
+    entry = root[1] if isinstance(root, list) and len(root) > 1 else None
+    options = root[2] if isinstance(root, list) and len(root) > 2 and isinstance(root[2], dict) else {}
+
+    message = {
+        "raw": root,
+        "tag": tag,
+        "options": options,
+        "records": [],
+        "mode": "unknown",
+    }
+
+    if isinstance(entry, list) and entry and isinstance(entry[0], list):
+        message["mode"] = "forward"
+        message["records"] = [_normalize_forward_record(item) for item in entry]
+    elif isinstance(entry, (bytes, bytearray)):
+        message["mode"] = "packed_forward"
+        message["records"] = _decode_packed_entries(bytes(entry), options)
+    elif len(root) >= 3:
+        message["mode"] = "message"
+        message["records"] = [_normalize_forward_record(root[1:4])]
+
+    return message
+
+
+def _handle_client(conn, address):
+    data_storage["connections"].append({"peer": address})
+    buffer = b""
+    conn.settimeout(0.5)
+
+    while not server_stop_event.is_set():
+        try:
+            chunk = conn.recv(4096)
+        except socket.timeout:
+            continue
+        except OSError:
+            break
+
+        if not chunk:
+            break
+
+        buffer += chunk
+
+        while buffer:
+            try:
+                message, offset = _unpack_obj(buffer, 0)
+            except IncompleteBuffer:
+                break
+
+            buffer = buffer[offset:]
+
+            if isinstance(message, list):
+                decoded = _classify_message(message)
+                data_storage["messages"].append(decoded)
+
+                chunk_id = decoded["options"].get("chunk")
+                if chunk_id is not None:
+                    _send_ack(conn, chunk_id)
+            else:
+                data_storage["messages"].append({"raw": message, "mode": "unknown", "tag": None, "options": {}, "records": []})
+
+
+def run_forward_server(port):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(("127.0.0.1", port))
+        server.listen()
+        server.settimeout(0.5)
+        logger.info("Starting forward server on port %s", port)
+
+        while not server_stop_event.is_set():
+            try:
+                conn, address = server.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+            with conn:
+                _handle_client(conn, address)
+
+
+def forward_server_run(port):
+    global server_thread, server_port
+
+    reset_forward_server_state()
+    server_port = port
+    server_thread = threading.Thread(target=run_forward_server, args=(port,), daemon=True)
+    server_thread.start()
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            if sock.connect_ex(("127.0.0.1", port)) == 0:
+                return server_thread
+        time.sleep(0.1)
+
+    raise TimeoutError(f"Timed out waiting for forward server on port {port}")
+
+
+def forward_server_stop():
+    server_stop_event.set()
+    if server_port is not None:
+        try:
+            with socket.create_connection(("127.0.0.1", server_port), timeout=0.2):
+                pass
+        except Exception:
+            pass

--- a/src/server/http_server.py
+++ b/src/server/http_server.py
@@ -16,11 +16,12 @@
 
 import json
 import logging
+import gzip
 import threading
 import time
 
 from flask import Flask, request, jsonify, Response
-from waitress import serve
+from werkzeug.serving import make_server
 
 app = Flask(__name__)
 data_storage = {"payloads": [], "requests": []}
@@ -50,11 +51,13 @@ oauth_token_response = {
 }
 logger = logging.getLogger(__name__)
 server_thread = None
+server_instances = []
 
 
 def reset_http_server_state():
     data_storage["payloads"] = []
     data_storage["requests"] = []
+    server_instances.clear()
     response_config.update(
         {
             "status_code": 200,
@@ -109,22 +112,48 @@ def _build_response():
 
 
 def _record_request():
-    data = request.get_json(silent=True)
-    raw_data = request.get_data(cache=True).decode("utf-8", errors="replace")
+    raw_payload = request.get_data(cache=True)
+    decoded_payload = _decode_payload(raw_payload)
+    data = _decode_json_payload(decoded_payload)
+    raw_data = raw_payload.decode("utf-8", errors="replace")
+    decoded_data = decoded_payload.decode("utf-8", errors="replace")
+
     data_storage["payloads"].append(data)
     data_storage["requests"].append(
         {
             "path": request.path,
+            "query_string": request.query_string.decode("utf-8", errors="replace"),
             "method": request.method,
             "headers": dict(request.headers),
             "raw_data": raw_data,
+            "decoded_data": decoded_data,
             "json": data,
         }
     )
 
 
+def _decode_payload(raw_payload):
+    if request.headers.get("Content-Encoding", "").lower() == "gzip":
+        return gzip.decompress(raw_payload)
+
+    return raw_payload
+
+
+def _decode_json_payload(decoded_payload):
+    if not decoded_payload:
+        return None
+
+    try:
+        return json.loads(decoded_payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+
 @app.route('/data', methods=['POST'])
-def receive_data():
+@app.route('/shared', methods=['POST'])
+@app.route('/solo', methods=['POST'])
+@app.route('/dataCollectionRules/<path:subpath>', methods=['POST'])
+def receive_data(subpath=None):
     _record_request()
     return _build_response()
 
@@ -156,18 +185,38 @@ def ping():
 @app.route('/shutdown', methods=['POST'])
 def shutdown():
     logger.info("HTTP server shutdown requested")
+    for server_instance in list(server_instances):
+        threading.Thread(target=server_instance.shutdown, daemon=True).start()
     return jsonify({"status": "shutting down"}), 200
 
 
-def run_server(port=60000):
-    serve(app, host='0.0.0.0', port=port, threads=1)
+def run_server(port=60000, *, use_tls=False, tls_crt_file=None, tls_key_file=None):
+    ssl_context = None
+    if use_tls:
+        ssl_context = (tls_crt_file, tls_key_file)
+
+    server_instance = make_server("0.0.0.0", port, app, ssl_context=ssl_context)
+    server_instances.append(server_instance)
+    server_instance.serve_forever()
 
 
-def http_server_run(port=60000):
+def http_server_run(port=60000, *, use_tls=False, tls_crt_file=None, tls_key_file=None,
+                    reset_state=True):
     global server_thread
 
-    reset_http_server_state()
+    if reset_state:
+        reset_http_server_state()
+
     logger.info("Starting HTTP server on port %s", port)
-    server_thread = threading.Thread(target=run_server, kwargs={"port": port}, daemon=True)
+    server_thread = threading.Thread(
+        target=run_server,
+        kwargs={
+            "port": port,
+            "use_tls": use_tls,
+            "tls_crt_file": tls_crt_file,
+            "tls_key_file": tls_key_file,
+        },
+        daemon=True,
+    )
     server_thread.start()
     return server_thread

--- a/src/server/kafka_server.py
+++ b/src/server/kafka_server.py
@@ -1,0 +1,416 @@
+#  Fluent Bit
+#  ==========
+#  Copyright (C) 2015-2026 The Fluent Bit Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import socket
+import struct
+import threading
+
+
+logger = logging.getLogger(__name__)
+
+API_KEY_PRODUCE = 0
+API_KEY_METADATA = 3
+API_KEY_API_VERSIONS = 18
+
+BROKER_NODE_ID = 1
+
+data_storage = {
+    "connections": [],
+    "requests": [],
+    "messages": [],
+}
+
+server_thread = None
+server_socket = None
+server_port = None
+server_stop_event = threading.Event()
+server_ready_event = threading.Event()
+
+
+def reset_kafka_server_state():
+    data_storage["connections"] = []
+    data_storage["requests"] = []
+    data_storage["messages"] = []
+    server_stop_event.clear()
+    server_ready_event.clear()
+
+
+def _recv_exact(sock, size):
+    chunks = []
+    remaining = size
+
+    while remaining > 0:
+        chunk = sock.recv(remaining)
+        if not chunk:
+            return None
+        chunks.append(chunk)
+        remaining -= len(chunk)
+
+    return b"".join(chunks)
+
+
+def _read_int16(data, offset):
+    return struct.unpack_from(">h", data, offset)[0], offset + 2
+
+
+def _read_int32(data, offset):
+    return struct.unpack_from(">i", data, offset)[0], offset + 4
+
+
+def _read_int64(data, offset):
+    return struct.unpack_from(">q", data, offset)[0], offset + 8
+
+
+def _read_string(data, offset):
+    length, offset = _read_int16(data, offset)
+    if length < 0:
+        return None, offset
+    end = offset + length
+    return data[offset:end].decode("utf-8", errors="replace"), end
+
+
+def _read_bytes(data, offset):
+    length, offset = _read_int32(data, offset)
+    if length < 0:
+        return None, offset
+    end = offset + length
+    return data[offset:end], end
+
+
+def _read_array_length(data, offset):
+    return _read_int32(data, offset)
+
+
+def _parse_request_header(payload):
+    api_key, offset = _read_int16(payload, 0)
+    api_version, offset = _read_int16(payload, offset)
+    correlation_id, offset = _read_int32(payload, offset)
+    client_id, offset = _read_string(payload, offset)
+
+    return {
+        "api_key": api_key,
+        "api_version": api_version,
+        "correlation_id": correlation_id,
+        "client_id": client_id,
+        "body": payload[offset:],
+    }
+
+
+def _encode_string(value):
+    encoded = value.encode("utf-8")
+    return struct.pack(">h", len(encoded)) + encoded
+
+
+def _encode_response(correlation_id, body):
+    frame = struct.pack(">i", correlation_id) + body
+    return struct.pack(">i", len(frame)) + frame
+
+
+def _encode_metadata_response(topics, host, port):
+    body = []
+    body.append(struct.pack(">i", 1))
+    body.append(struct.pack(">i", BROKER_NODE_ID))
+    body.append(_encode_string(host))
+    body.append(struct.pack(">i", port))
+
+    body.append(struct.pack(">i", len(topics)))
+    for topic in topics:
+        body.append(struct.pack(">h", 0))
+        body.append(_encode_string(topic))
+        body.append(struct.pack(">i", 1))
+        body.append(struct.pack(">h", 0))
+        body.append(struct.pack(">i", 0))
+        body.append(struct.pack(">i", BROKER_NODE_ID))
+        body.append(struct.pack(">i", 1))
+        body.append(struct.pack(">i", BROKER_NODE_ID))
+        body.append(struct.pack(">i", 1))
+        body.append(struct.pack(">i", BROKER_NODE_ID))
+
+    return b"".join(body)
+
+
+def _encode_produce_response(topic, partition=0, base_offset=0):
+    return b"".join(
+        [
+            struct.pack(">i", 1),
+            _encode_string(topic),
+            struct.pack(">i", 1),
+            struct.pack(">i", partition),
+            struct.pack(">h", 0),
+            struct.pack(">q", base_offset),
+        ]
+    )
+
+
+def _encode_api_versions_response(api_version):
+    api_versions = [
+        (API_KEY_PRODUCE, 0, 0),
+        (API_KEY_METADATA, 0, 0),
+        (API_KEY_API_VERSIONS, 0, 3),
+    ]
+
+    if api_version >= 3:
+        entries = []
+        for api_key, min_version, max_version in api_versions:
+            entries.append(
+                struct.pack(">h", api_key)
+                + struct.pack(">h", min_version)
+                + struct.pack(">h", max_version)
+                + b"\x00"
+            )
+
+        return b"".join(
+            [
+                struct.pack(">h", 0),
+                bytes([len(api_versions) + 1]),
+                b"".join(entries),
+                struct.pack(">i", 0),
+                b"\x00",
+            ]
+        )
+
+    body = [struct.pack(">h", 0), struct.pack(">i", len(api_versions))]
+    for api_key, min_version, max_version in api_versions:
+        body.append(struct.pack(">h", api_key))
+        body.append(struct.pack(">h", min_version))
+        body.append(struct.pack(">h", max_version))
+    if api_version >= 1:
+        body.append(struct.pack(">i", 0))
+    return b"".join(body)
+
+
+def _parse_metadata_request(body):
+    topic_count, offset = _read_array_length(body, 0)
+    topics = []
+
+    for _ in range(topic_count):
+        topic, offset = _read_string(body, offset)
+        topics.append(topic)
+
+    return topics
+
+
+def _parse_message_set(data):
+    messages = []
+    offset = 0
+
+    while offset < len(data):
+        if len(data) - offset < 12:
+            break
+
+        message_offset, offset = _read_int64(data, offset)
+        message_size, offset = _read_int32(data, offset)
+        end = offset + message_size
+
+        if end > len(data):
+            break
+
+        _, cursor = _read_int32(data, offset)
+        magic = data[cursor]
+        cursor += 1
+        attributes = data[cursor]
+        cursor += 1
+        key, cursor = _read_bytes(data, cursor)
+        value, cursor = _read_bytes(data, cursor)
+
+        if magic == 1 and cursor + 8 <= end:
+            cursor += 8
+
+        if attributes & 0x07:
+            raise ValueError("Compressed Kafka message sets are not supported by the fake broker")
+
+        messages.append(
+            {
+                "offset": message_offset,
+                "magic": magic,
+                "attributes": attributes,
+                "key": key,
+                "value": value,
+            }
+        )
+        offset = end
+
+    return messages
+
+
+def _parse_produce_request(body):
+    required_acks, offset = _read_int16(body, 0)
+    timeout_ms, offset = _read_int32(body, offset)
+    topic_count, offset = _read_array_length(body, offset)
+    produced_topics = []
+
+    for _ in range(topic_count):
+        topic, offset = _read_string(body, offset)
+        partition_count, offset = _read_array_length(body, offset)
+        partitions = []
+
+        for _ in range(partition_count):
+            partition, offset = _read_int32(body, offset)
+            message_set, offset = _read_bytes(body, offset)
+            records = _parse_message_set(message_set or b"")
+            partitions.append(
+                {
+                    "partition": partition,
+                    "records": records,
+                }
+            )
+
+        produced_topics.append(
+            {
+                "topic": topic,
+                "partitions": partitions,
+            }
+        )
+
+    return {
+        "required_acks": required_acks,
+        "timeout_ms": timeout_ms,
+        "topics": produced_topics,
+    }
+
+
+def _handle_request(sock, request, host, port):
+    data_storage["requests"].append(
+        {
+            "api_key": request["api_key"],
+            "api_version": request["api_version"],
+            "correlation_id": request["correlation_id"],
+            "client_id": request["client_id"],
+        }
+    )
+
+    if request["api_key"] == API_KEY_API_VERSIONS:
+        sock.sendall(
+            _encode_response(
+                request["correlation_id"],
+                _encode_api_versions_response(request["api_version"]),
+            )
+        )
+        return
+
+    if request["api_key"] == API_KEY_METADATA:
+        topics = _parse_metadata_request(request["body"])
+        sock.sendall(
+            _encode_response(
+                request["correlation_id"],
+                _encode_metadata_response(topics, host, port),
+            )
+        )
+        return
+
+    if request["api_key"] == API_KEY_PRODUCE:
+        produced = _parse_produce_request(request["body"])
+        for topic_data in produced["topics"]:
+            for partition_data in topic_data["partitions"]:
+                for record in partition_data["records"]:
+                    data_storage["messages"].append(
+                        {
+                            "topic": topic_data["topic"],
+                            "partition": partition_data["partition"],
+                            "key": record["key"],
+                            "value": record["value"],
+                            "magic": record["magic"],
+                            "attributes": record["attributes"],
+                            "client_id": request["client_id"],
+                        }
+                    )
+
+        first_topic = produced["topics"][0]["topic"] if produced["topics"] else "test"
+        sock.sendall(
+            _encode_response(
+                request["correlation_id"],
+                _encode_produce_response(first_topic),
+            )
+        )
+        return
+
+    logger.warning("Unsupported Kafka API key %s", request["api_key"])
+
+
+def _connection_loop(client, address, host, port):
+    data_storage["connections"].append({"address": address})
+
+    with client:
+        while not server_stop_event.is_set():
+            header = _recv_exact(client, 4)
+            if not header:
+                return
+
+            frame_size = struct.unpack(">i", header)[0]
+            payload = _recv_exact(client, frame_size)
+            if payload is None:
+                return
+
+            request = _parse_request_header(payload)
+            _handle_request(client, request, host, port)
+
+
+def _server_loop(host, port):
+    global server_socket, server_port
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((host, port))
+    sock.listen(16)
+    sock.settimeout(0.2)
+
+    server_socket = sock
+    server_port = port
+    server_ready_event.set()
+    logger.info("Starting fake Kafka broker on %s:%s", host, port)
+
+    try:
+        while not server_stop_event.is_set():
+            try:
+                client, address = sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+            worker = threading.Thread(
+                target=_connection_loop,
+                args=(client, address, host, port),
+                daemon=True,
+            )
+            worker.start()
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+        server_socket = None
+
+
+def kafka_server_run(port, host="127.0.0.1"):
+    global server_thread
+
+    reset_kafka_server_state()
+    server_thread = threading.Thread(target=_server_loop, args=(host, port), daemon=True)
+    server_thread.start()
+    server_ready_event.wait(timeout=5)
+    return server_thread
+
+
+def kafka_server_stop():
+    server_stop_event.set()
+
+    if server_socket is not None:
+        try:
+            server_socket.close()
+        except OSError:
+            pass

--- a/src/server/s3_server.py
+++ b/src/server/s3_server.py
@@ -1,0 +1,104 @@
+#  Fluent Bit
+#  ==========
+#  Copyright (C) 2015-2026 The Fluent Bit Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+logger = logging.getLogger(__name__)
+
+data_storage = {
+    "requests": [],
+}
+
+server_thread = None
+server_instance = None
+
+
+def reset_s3_server_state():
+    data_storage["requests"] = []
+
+
+class _S3RequestHandler(BaseHTTPRequestHandler):
+    server_version = "FakeS3/1.0"
+    protocol_version = "HTTP/1.1"
+
+    def _record_request(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length) if length > 0 else b""
+        data_storage["requests"].append(
+            {
+                "method": self.command,
+                "path": self.path,
+                "headers": dict(self.headers),
+                "body": body,
+            }
+        )
+
+    def do_PUT(self):
+        self._record_request()
+        self.send_response(200)
+        self.send_header("ETag", '"fake-s3-etag"')
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_POST(self):
+        self._record_request()
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_GET(self):
+        if self.path == "/ping":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", "18")
+            self.end_headers()
+            self.wfile.write(b'{"status":"pong"}')
+            return
+
+        self.send_response(404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, format, *args):
+        logger.debug("Fake S3 server: %s", format % args)
+
+
+def s3_server_run(port):
+    global server_thread
+    global server_instance
+
+    reset_s3_server_state()
+    server_instance = ThreadingHTTPServer(("0.0.0.0", port), _S3RequestHandler)
+    server_thread = threading.Thread(target=server_instance.serve_forever, daemon=True)
+    server_thread.start()
+    return server_thread
+
+
+def s3_server_stop():
+    global server_instance
+    global server_thread
+
+    if server_instance is not None:
+        server_instance.shutdown()
+        server_instance.server_close()
+        server_instance = None
+
+    if server_thread is not None:
+        server_thread.join(timeout=5)
+        server_thread = None


### PR DESCRIPTION
This PR imports the latest Python integration test-suite additions as plain file updates, without   merging external history, and adapts them to the capabilities of the current Fluent Bit binary.

It adds reusable local test helpers and runners, new scenario coverage for in_forward, in_mqtt, out_kafka, out_s3, and out_stdout, plus expanded protocol and OAuth2 coverage across existing  scenarios including Elasticsearch, OpenTelemetry, Prometheus remote write, Splunk, Azure Logs Ingestion, and out_opentelemetry.